### PR TITLE
Fix BoundaryBench root-relative experiment paths

### DIFF
--- a/boundarybench/experiment/README.md
+++ b/boundarybench/experiment/README.md
@@ -54,6 +54,9 @@ npm run boundarybench:experiment -- freeze \
   --out .boundarybench/pilot.manifest.json
 ```
 
+Experiment command paths are resolved from the repository root, including when
+npm launches the implementation from its workspace.
+
 The command refuses to overwrite an existing manifest. The manifest binds the
 commit, deterministic protocol, task and verifier digests, models, effort,
 pricing snapshot, prompt/tool contract through the harness commit, immutable

--- a/boundarybench/experiment/src/cli.ts
+++ b/boundarybench/experiment/src/cli.ts
@@ -25,6 +25,10 @@ import type { FrozenExperimentManifest } from './types.js';
 
 const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
 
+function resolveRepositoryPath(value: string): string {
+  return path.resolve(repositoryRoot, value);
+}
+
 function help(): string {
   return [
     'BoundaryBench exploratory experiment',
@@ -37,6 +41,7 @@ function help(): string {
     '',
     'Live execution requires BOUNDARYBENCH_LIVE=1 and both provider API keys.',
     'Freeze and run refuse a dirty worktree. A frozen manifest requires an immutable Docker image digest.',
+    'Relative option paths are resolved from the repository root.',
     '',
   ].join('\n');
 }
@@ -123,8 +128,8 @@ async function readRunSetReceipts(
 }
 
 async function freeze(argv: string[]): Promise<void> {
-  const configPath = path.resolve(process.cwd(), option(argv, '--config'));
-  const outputPath = path.resolve(process.cwd(), option(argv, '--out'));
+  const configPath = resolveRepositoryPath(option(argv, '--config'));
+  const outputPath = resolveRepositoryPath(option(argv, '--out'));
   const commit = await assertCleanWorktree();
   const draft = await loadExperimentDraft(
     configPath,
@@ -144,11 +149,11 @@ async function freeze(argv: string[]): Promise<void> {
 }
 
 async function run(argv: string[]): Promise<void> {
-  const manifestPath = path.resolve(process.cwd(), option(argv, '--manifest'));
+  const manifestPath = resolveRepositoryPath(option(argv, '--manifest'));
   const outputIndex = argv.indexOf('--output');
   const outputRoot = outputIndex < 0
     ? path.join(repositoryRoot, '.boundarybench', 'runs')
-    : path.resolve(process.cwd(), option(argv, '--output'));
+    : resolveRepositoryPath(option(argv, '--output'));
   const manifest = await readManifest(manifestPath);
   const receipts = await runExperiment(manifest, {
     repositoryRoot,
@@ -162,7 +167,7 @@ async function run(argv: string[]): Promise<void> {
 }
 
 async function report(argv: string[]): Promise<void> {
-  const runSetRoot = path.resolve(process.cwd(), option(argv, '--run-set'));
+  const runSetRoot = resolveRepositoryPath(option(argv, '--run-set'));
   const manifest = await readManifest(path.join(runSetRoot, 'manifest.json'));
   const receipts = await readRunSetReceipts(runSetRoot, manifest);
   const summary = await writeRunSetReport(runSetRoot, manifest, receipts);

--- a/boundarybench/experiment/test/runner.test.ts
+++ b/boundarybench/experiment/test/runner.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import {
   mkdtemp,
   readFile,
   rm,
 } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -19,6 +21,7 @@ import {
 import type { ExperimentDraft } from '../src/types.js';
 
 const digest = `sha256:${'a'.repeat(64)}`;
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
 
 function minimalDraft(): ExperimentDraft {
   return {
@@ -119,6 +122,32 @@ test('live experiment execution requires an explicit environment opt-in', async 
     }),
     /BOUNDARYBENCH_LIVE=1/,
   );
+});
+
+test('root experiment commands resolve relative paths from the repository root', () => {
+  const result = spawnSync(
+    'npm',
+    [
+      'run',
+      'boundarybench:experiment',
+      '--',
+      'run',
+      '--manifest',
+      'boundarybench/experiment/pilot.config.example.json',
+    ],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        BOUNDARYBENCH_LIVE: '',
+      },
+    },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Manifest is malformed/);
+  assert.doesNotMatch(result.stderr, /ENOENT/);
 });
 
 test('report generation writes the claim boundary and machine-readable summary', async t => {


### PR DESCRIPTION
## Summary
- resolve every experiment CLI option path from the repository root
- cover the actual root npm workspace invocation with an integration regression
- document the path contract in CLI help and the operator README

## Root cause
The root npm script delegates to the experiment workspace. npm changes the process working directory to `boundarybench/experiment`, while the CLI previously resolved user-supplied paths with `process.cwd()`. Documented repository-relative paths were therefore duplicated beneath the workspace directory.

## Developer impact
The documented root-level `freeze`, `run`, and `report` commands now resolve relative paths consistently from the repository root. Absolute paths remain supported.

## Validation
- `npm run build`
- Docker-enabled `npm test`: 46 deterministic tests, 31 harness tests, and 8 experiment tests passed
- `npm run typecheck`
- deterministic BoundaryBench: 35/35 conformance cases, 5/5 mutants killed, evidence matched
- all five corpus tasks passed validation
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- documented root-relative `freeze` command reached the intended config and failed closed on its intentionally mutable image reference, with no `ENOENT` and no artifact written

No live provider calls were made.