### PR TITLE
Freeze Agent Run request and terminal receipt contracts v0.1

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,12 +15,24 @@ _Avoid_: Wrapper, provider agent
 The Rust module that returns the decision required before a protected effect.
 _Avoid_: Provider adapter, policy wrapper
 
+**Agent Run Request**:
+The immutable, versioned input that binds one Agent Run to its exact subject, requested capability, constraints, policy identities, resource budget, approval context, and verification requirements.
+_Avoid_: Provider request, workflow run request
+
+**Agent Run**:
+One bounded execution governed through GAAP's integrity decisions that produces exactly one Terminal Run Receipt.
+_Avoid_: ThreadLoop Workflow Run, provider session
+
+**Terminal Run Receipt**:
+The content-addressed record of an Agent Run's terminal status, decisions, observed effects, evidence, resource usage, and exact resulting subject.
+_Avoid_: Log, transcript, Trial result
+
 **Gate**:
 A deterministic decision point that returns `allow`, `ask`, or `block` for a protected effect.
 _Avoid_: Guardrail, suggestion
 
 **Trial**:
-One frozen execution of one task, provider, model, and condition that produces exactly one terminal receipt.
+One frozen experimental execution of one task, provider, model, and condition that contributes to an Evidence Packet.
 _Avoid_: Session, sample, attempt
 
 **Condition**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ cargo fmt --check
 cargo clippy --locked --all-targets -- -D warnings
 cargo test --locked
 cargo build --locked
+cargo run --locked --example generate-contract-schemas -- --check
+cargo run --locked --example generate-contract-examples -- --check
 ```
 
 Changes to `RunCoordinator` decisions must also be tested through the pinned
@@ -25,6 +27,10 @@ hand or update it to make a failing implementation appear conformant.
 - Treat unknown authority, evidence, usage, and schema versions as failures.
 - Version the external subject protocol instead of adding unrecognized fields
   to an existing version.
+- Version Agent Run contracts when adding or changing a field, lifecycle state,
+  event type, evidence type, canonicalization rule, or validation rule.
+- Regenerate schemas and examples intentionally; never edit their digests or
+  generated schema documents to hide contract drift.
 - Keep implementation evidence separate from claims about a complete agent
   loop or production outcomes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +66,24 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cfg-if"
@@ -37,6 +111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,10 +127,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fraction"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
+dependencies = [
+ "num",
+ "num-bigint",
+]
+
+[[package]]
 name = "gaap"
 version = "0.1.0"
 dependencies = [
+ "jsonschema",
+ "schemars",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2",
 ]
@@ -66,10 +208,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
+]
 
 [[package]]
 name = "libc"
@@ -78,10 +313,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "proc-macro2"
@@ -100,6 +469,130 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "referencing"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom",
+ "hashbrown",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -128,7 +621,29 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -156,6 +671,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,16 +726,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,14 @@ repository = "https://github.com/nnennandukwe/governed-agent-autonomy-patterns"
 publish = false
 
 [dependencies]
+schemars = "1.2.2"
 serde = { version = "1.0", features = ["derive"] }
+serde_jcs = "0.2.0"
 serde_json = "1.0"
 sha2 = "0.10"
+
+[dev-dependencies]
+jsonschema = { version = "0.52.1", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ tools, repository mutations, sandboxes, or verifiers.
 | Path or interface | Current behavior | Developer use |
 | --- | --- | --- |
 | [`RunCoordinator::evaluate(gate, input)`](./src/lib.rs) | Accepts a typed `Gate` and normalized JSON input, then returns an `allow`, `ask`, or `block` decision with a code and effects. | Put one deterministic decision module behind future provider, tool, and runtime adapters. |
+| [`gaap::contracts`](./src/contracts) | Defines and validates the provider-neutral Agent Run Request, lifecycle, ordered event ledger, and Terminal Run Receipt `0.1.0`. | Integrate against canonical Rust types or generated language-neutral JSON Schemas without importing provider SDK types. |
+| [`schemas/agent-run/v0.1.0`](./schemas/agent-run/v0.1.0) | Freezes Draft 2020-12 request and receipt schemas with strict fields, versions, enums, digests, and safe integers. | Generate or validate cross-language contract documents. |
+| [`examples/contracts/v0.1.0`](./examples/contracts/v0.1.0) | Provides one request and seven digest-valid terminal outcomes. | Inspect completed and failure-path contract behavior. |
 | `gaap run-invariant` | Reads a RunInvariant request from stdin and writes one response to stdout. | Test the Rust coordinator without importing its crate or depending on Rust. |
 | [`evidence/run-invariant-subject-v0.1.0.json`](./evidence/run-invariant-subject-v0.1.0.json) | Records the Rust subject's exact 35/35 result and request digest. | Reproduce the current external conformance claim. |
 | [`docs/patterns`](./docs/patterns) | Defines the five integrity gates and their operating intent. | Design the larger agent-run lifecycle and review other systems. |
@@ -35,7 +38,12 @@ Implemented and tested now:
 - fail-closed usage accounting and bounded overage approval;
 - separate mutation and completion authorization;
 - a language-neutral RunInvariant process adapter; and
-- a 35/35 black-box conformance packet for the frozen protocol.
+- a 35/35 black-box conformance packet for the frozen protocol;
+- provider-neutral Agent Run Request and Terminal Run Receipt Rust types;
+- RFC 8785 canonical request and receipt-body digests;
+- fail-closed policy, lifecycle, evidence, subject-freshness, and usage validation;
+- generated Draft 2020-12 JSON Schemas; and
+- completed, blocked, failed, interrupted, budget-exhausted, denied-effect, and stale-verification examples.
 
 Not implemented yet:
 
@@ -60,6 +68,8 @@ cd governed-agent-autonomy-patterns
 cargo test --locked
 cargo clippy --locked --all-targets -- -D warnings
 cargo build --locked
+cargo run --locked --example generate-contract-schemas -- --check
+cargo run --locked --example generate-contract-examples -- --check
 ```
 
 Inspect the CLI:
@@ -113,6 +123,12 @@ Architecture decisions:
 
 - [`0001: Own the agent loop`](./docs/adr/0001-own-the-agent-loop.md)
 - [`0002: Use an external conformance seam`](./docs/adr/0002-run-invariant-process-seam.md)
+- [`0003: Freeze the Agent Run contract as canonical evidence`](./docs/adr/0003-freeze-agent-run-contract.md)
+
+The normative contract guide is
+[`Agent Run Contract 0.1.0`](./docs/contracts/agent-run-v0.1.md). Contract
+receipts are content-addressed but not signed; they provide integrity and
+interoperability, not producer authenticity.
 
 ## Pattern Library
 

--- a/docs/adr/0003-freeze-agent-run-contract.md
+++ b/docs/adr/0003-freeze-agent-run-contract.md
@@ -1,0 +1,16 @@
+# ADR 0003: Freeze The Agent Run Contract As Canonical Evidence
+
+Status: Accepted
+
+## Decision
+
+GAAP will exchange Agent Run Requests and Terminal Run Receipts as provider-neutral, versioned JSON contracts. SHA-256 digests cover RFC 8785 canonical JSON; a Terminal Run Receipt envelopes a digest-bearing immutable body whose ordered, closed event ledger is the authority for lifecycle and subject freshness.
+
+Policy support is an exact caller-supplied allowlist, not a second policy evaluator. Receipt evidence is content-addressed metadata rather than embedded provider output, and contract versions fail closed on unknown fields, identities, states, events, or evidence types.
+
+## Consequences
+
+- Equivalent JSON objects have the same digest across languages while event order remains significant.
+- New fields, states, event types, evidence types, or validation rules require a new contract version.
+- Receipt digests prove integrity and addressing, not signer authenticity.
+- RunInvariant remains a separate process conformance protocol for `RunCoordinator` decisions.

--- a/docs/contracts/agent-run-v0.1.md
+++ b/docs/contracts/agent-run-v0.1.md
@@ -1,0 +1,136 @@
+# Agent Run Contract 0.1.0
+
+This contract defines the provider-neutral JSON boundary for starting one
+governed Agent Run and recording its terminal result. It freezes evidence
+shapes and validation rules only; it does not implement the model/tool loop,
+adapters, persistence, recovery, or receipt signing.
+
+## Contract Documents
+
+- `gaap.agent-run-request/0.1.0` starts one Agent Run.
+- `gaap.terminal-run-receipt/0.1.0` records one terminal outcome.
+- The generated JSON Schemas use Draft 2020-12 and reject unknown fields.
+- Any new field, state, event, evidence type, or validation rule requires a new
+  contract version.
+
+The Rust types and validators live in `gaap::contracts`. The generated schemas
+live under `schemas/agent-run/v0.1.0`, and complete examples live under
+`examples/contracts/v0.1.0`.
+
+## Agent Run Request
+
+An `AgentRunRequest` binds immutable run intent to:
+
+- opaque request and run IDs;
+- an exact repository or artifact locator and SHA-256 subject digest;
+- a requested engineering capability name, version, and digest;
+- task instructions and ordered textual constraints;
+- one or more exact policy name/version/digest identities;
+- safe-integer cost, elapsed-time, token, and tool-call budgets;
+- existing approval evidence bound to actor, scope, and exact subject; and
+- required independent verification evidence types.
+
+`ContractSupport` is an exact allowlist of supported policy identities. It has
+no wildcard and does not evaluate policy. `validate_request` rejects an
+otherwise well-formed request when any identity is absent from that allowlist.
+
+## Lifecycle
+
+The initial state is `accepted`. The ordered event ledger permits:
+
+```text
+accepted -> planning
+planning -> awaiting_authority | executing
+awaiting_authority -> planning | executing
+executing -> awaiting_authority | verifying
+verifying -> executing | completed
+any non-terminal state -> blocked | failed | interrupted
+terminal state -> no transition
+```
+
+`awaiting_authority` is resumable. `blocked`, `failed`, and `interrupted` are
+distinct terminal outcomes. A terminal receipt's last event must transition to
+the exact status declared by its body.
+
+## Terminal Run Receipt
+
+The envelope avoids a self-referential digest:
+
+```json
+{
+  "receipt_digest": "sha256:<64 lowercase hex>",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0"
+  }
+}
+```
+
+The body binds the request digest, IDs, initial and resulting subject digests,
+terminal status and reason, cumulative usage, and a contiguous event ledger
+numbered from `1`. The closed event union records:
+
+- lifecycle transitions;
+- plan and approval evidence;
+- `RunCoordinator` protected-effect decisions;
+- authorized tool executions and observed mutations;
+- independent verification;
+- cumulative resource usage; and
+- interruption evidence.
+
+Evidence entries contain a closed evidence type, content digest, and optional
+locator. Raw tool output and provider messages are not embedded.
+
+## Canonicalization And Digests
+
+GAAP uses RFC 8785 JSON Canonicalization Scheme bytes and lowercase SHA-256:
+
+```text
+request_digest = SHA-256(JCS(AgentRunRequest))
+receipt_digest = SHA-256(JCS(TerminalRunReceiptBody))
+```
+
+Contract numbers are non-negative integers no larger than
+`9_007_199_254_740_991`; floating-point values are absent. Array order remains
+significant, including task constraints, policy identities, required evidence,
+and receipt events.
+
+Receipt digests detect mutation and provide content addressing. They do not
+prove who produced a receipt; authenticity and signatures are later work.
+
+## Completion Invariants
+
+`seal_terminal_receipt` and `verify_terminal_receipt` require a
+completed run to demonstrate all of the following:
+
+1. Plan approval evidence appears in the ledger and matches approval context
+   from the request.
+2. Every tool execution and mutation references an earlier decision with the
+   same protected-effect digest and an `allow` outcome.
+3. `ask` and `block` never authorize an observed effect.
+4. The resulting subject equals the last observed mutation result.
+5. Passing verification comes from a different actor, carries all required
+   evidence types, and targets the latest subject after its last mutation.
+6. A later `workflow.completion_authorized` decision is bound to that same
+   verified subject.
+7. Final cumulative usage matches the receipt body and remains within the
+   request budget.
+
+A later mutation invalidates earlier verification for completion. Non-completed
+receipts may preserve stale or failed evidence so operators can diagnose why
+the run stopped.
+
+## RunInvariant Is Separate
+
+RunInvariant sends normalized decision cases to the `gaap run-invariant`
+process interface and checks `RunCoordinator` conformance. An Agent Run Request
+starts a future bounded runtime; a Terminal Run Receipt records a runtime
+outcome. Neither contract is a RunInvariant request, response, fixture, or
+Evidence Packet.
+
+## Reproduce The Artifacts
+
+```bash
+cargo run --locked --example generate-contract-schemas -- --check
+cargo run --locked --example generate-contract-examples -- --check
+cargo test --locked --test contracts --test schema_contracts
+```

--- a/docs/contracts/agent-run-v0.1.md
+++ b/docs/contracts/agent-run-v0.1.md
@@ -33,6 +33,9 @@ An `AgentRunRequest` binds immutable run intent to:
 `ContractSupport` is an exact allowlist of supported policy identities. It has
 no wildcard and does not evaluate policy. `validate_request` rejects an
 otherwise well-formed request when any identity is absent from that allowlist.
+Approval context supplied with a request must target that request's exact
+subject digest; approvals recorded later in the ledger remain bound to the
+subject named by their own scope and digest.
 
 ## Lifecycle
 
@@ -102,8 +105,9 @@ prove who produced a receipt; authenticity and signatures are later work.
 `seal_terminal_receipt` and `verify_terminal_receipt` require a
 completed run to demonstrate all of the following:
 
-1. Every tool execution and mutation references an earlier decision with the
-   same protected-effect digest and an `allow` outcome.
+1. Every tool execution references an earlier `permission` decision, and every
+   mutation references an earlier `workflow` decision, with the same
+   protected-effect and subject digests and an `allow` outcome.
 2. `ask` and `block` never authorize an observed effect.
 3. The resulting subject equals the last observed mutation result.
 4. Passing verification comes from a different actor, carries all required

--- a/docs/contracts/agent-run-v0.1.md
+++ b/docs/contracts/agent-run-v0.1.md
@@ -102,17 +102,15 @@ prove who produced a receipt; authenticity and signatures are later work.
 `seal_terminal_receipt` and `verify_terminal_receipt` require a
 completed run to demonstrate all of the following:
 
-1. Plan approval evidence appears in the ledger and matches approval context
-   from the request.
-2. Every tool execution and mutation references an earlier decision with the
+1. Every tool execution and mutation references an earlier decision with the
    same protected-effect digest and an `allow` outcome.
-3. `ask` and `block` never authorize an observed effect.
-4. The resulting subject equals the last observed mutation result.
-5. Passing verification comes from a different actor, carries all required
+2. `ask` and `block` never authorize an observed effect.
+3. The resulting subject equals the last observed mutation result.
+4. Passing verification comes from a different actor, carries all required
    evidence types, and targets the latest subject after its last mutation.
-6. A later `workflow.completion_authorized` decision is bound to that same
+5. A later `workflow.completion_authorized` decision is bound to that same
    verified subject.
-7. Final cumulative usage matches the receipt body and remains within the
+6. Final cumulative usage matches the receipt body and remains within the
    request budget.
 
 A later mutation invalidates earlier verification for completion. Non-completed

--- a/examples/contracts/v0.1.0/agent-run-request.json
+++ b/examples/contracts/v0.1.0/agent-run-request.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "gaap.agent-run-request/0.1.0",
+  "request_id": "request-001",
+  "run_id": "run-001",
+  "subject": {
+    "kind": "repository",
+    "locator": "https://example.invalid/repository",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "requested_capability": {
+    "name": "change-code",
+    "version": "1",
+    "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "task": {
+    "instructions": "Implement the approved change.",
+    "constraints": [
+      "Do not publish a release."
+    ]
+  },
+  "policies": [
+    {
+      "name": "gaap.run-coordinator",
+      "version": "0.1.0",
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "resource_budget": {
+    "max_cost_micros": 1000000,
+    "max_elapsed_ms": 60000,
+    "max_model_tokens": 100000,
+    "max_tool_calls": 100
+  },
+  "approval_context": [
+    {
+      "approval_id": "approval-001",
+      "actor_id": "maintainer-001",
+      "scope": "plan",
+      "subject_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "evidence": {
+        "evidence_type": "approval",
+        "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "locator": null
+      }
+    }
+  ],
+  "required_verification": {
+    "independence": "different_actor",
+    "evidence_types": [
+      "command_output",
+      "artifact"
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/agent-run-request.json
+++ b/examples/contracts/v0.1.0/agent-run-request.json
@@ -35,8 +35,8 @@
     {
       "approval_id": "approval-001",
       "actor_id": "maintainer-001",
-      "scope": "plan",
-      "subject_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "scope": "subject",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "evidence": {
         "evidence_type": "approval",
         "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",

--- a/examples/contracts/v0.1.0/blocked.json
+++ b/examples/contracts/v0.1.0/blocked.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:51019ea0ccacbdc086e59202fbf4564f4e693563991b2208483dac431407853e",
+  "receipt_digest": "sha256:826bef2f6e0022c873067f2f0629e0846d8ffc7f745999be5c9233b3014219fb",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "terminal_status": "blocked",

--- a/examples/contracts/v0.1.0/blocked.json
+++ b/examples/contracts/v0.1.0/blocked.json
@@ -1,0 +1,65 @@
+{
+  "receipt_digest": "sha256:51019ea0ccacbdc086e59202fbf4564f4e693563991b2208483dac431407853e",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "terminal_status": "blocked",
+    "terminal_reason": "authority.required",
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 2,
+        "decision_id": "decision-authority-001",
+        "gate": "permission",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "decision": {
+          "outcome": "ask",
+          "code": "permission.policy_requires_approval",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 3,
+        "from": "planning",
+        "to": "awaiting_authority",
+        "reason": "authority.required"
+      },
+      {
+        "event_type": "usage",
+        "sequence": 4,
+        "usage": {
+          "cost_micros": 0,
+          "elapsed_ms": 0,
+          "model_tokens": 0,
+          "tool_calls": 0
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 5,
+        "from": "awaiting_authority",
+        "to": "blocked",
+        "reason": "authority.required"
+      }
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/budget-exhausted.json
+++ b/examples/contracts/v0.1.0/budget-exhausted.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:2f47ac68e55202d526538c3acfe45325d94bfe081a562d5743fa333162a87681",
+  "receipt_digest": "sha256:43de2b72d6d8707e77aeb179599d47d2f1d46ff738dced9be261560e45bfe55d",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "terminal_status": "blocked",

--- a/examples/contracts/v0.1.0/budget-exhausted.json
+++ b/examples/contracts/v0.1.0/budget-exhausted.json
@@ -1,0 +1,65 @@
+{
+  "receipt_digest": "sha256:2f47ac68e55202d526538c3acfe45325d94bfe081a562d5743fa333162a87681",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "terminal_status": "blocked",
+    "terminal_reason": "runtime.hard_stop",
+    "usage": {
+      "cost_micros": 1000000,
+      "elapsed_ms": 60000,
+      "model_tokens": 100000,
+      "tool_calls": 100
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 2,
+        "from": "planning",
+        "to": "executing",
+        "reason": null
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 3,
+        "decision_id": "decision-budget-001",
+        "gate": "runtime",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "decision": {
+          "outcome": "block",
+          "code": "runtime.hard_stop",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "usage",
+        "sequence": 4,
+        "usage": {
+          "cost_micros": 1000000,
+          "elapsed_ms": 60000,
+          "model_tokens": 100000,
+          "tool_calls": 100
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 5,
+        "from": "executing",
+        "to": "blocked",
+        "reason": "runtime.hard_stop"
+      }
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/completed.json
+++ b/examples/contracts/v0.1.0/completed.json
@@ -1,0 +1,157 @@
+{
+  "receipt_digest": "sha256:b9efa353c4f803a946be988b669b8f5ffa69ed234d8f39c7a20a9902aaef06c7",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "terminal_status": "completed",
+    "terminal_reason": "workflow.completion_authorized",
+    "usage": {
+      "cost_micros": 200000,
+      "elapsed_ms": 2000,
+      "model_tokens": 2500,
+      "tool_calls": 1
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "plan_recorded",
+        "sequence": 2,
+        "plan_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      {
+        "event_type": "approval_recorded",
+        "sequence": 3,
+        "approval": {
+          "approval_id": "approval-001",
+          "actor_id": "maintainer-001",
+          "scope": "plan",
+          "subject_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "evidence": {
+            "evidence_type": "approval",
+            "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "locator": null
+          }
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 4,
+        "from": "planning",
+        "to": "executing",
+        "reason": null
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 5,
+        "decision_id": "decision-tool-001",
+        "gate": "permission",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "decision": {
+          "outcome": "allow",
+          "code": "permission.policy_allowed",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "tool_execution",
+        "sequence": 6,
+        "decision_id": "decision-tool-001",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "action_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "capability_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "evidence": [
+          {
+            "evidence_type": "tool_execution",
+            "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+            "locator": null
+          }
+        ]
+      },
+      {
+        "event_type": "mutation",
+        "sequence": 7,
+        "decision_id": "decision-tool-001",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "before_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "after_subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "evidence": [
+          {
+            "evidence_type": "artifact",
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "locator": null
+          }
+        ]
+      },
+      {
+        "event_type": "usage",
+        "sequence": 8,
+        "usage": {
+          "cost_micros": 200000,
+          "elapsed_ms": 2000,
+          "model_tokens": 2500,
+          "tool_calls": 1
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 9,
+        "from": "executing",
+        "to": "verifying",
+        "reason": null
+      },
+      {
+        "event_type": "verification",
+        "sequence": 10,
+        "subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "implementer_id": "executor-001",
+        "verifier_id": "verifier-001",
+        "verdict": "PASS",
+        "evidence": [
+          {
+            "evidence_type": "command_output",
+            "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "locator": null
+          },
+          {
+            "evidence_type": "artifact",
+            "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            "locator": null
+          }
+        ]
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 11,
+        "decision_id": "decision-completion-001",
+        "gate": "workflow",
+        "protected_effect_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "decision": {
+          "outcome": "allow",
+          "code": "workflow.completion_authorized",
+          "effects": [
+            "record_completion"
+          ]
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 12,
+        "from": "verifying",
+        "to": "completed",
+        "reason": "workflow.completion_authorized"
+      }
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/completed.json
+++ b/examples/contracts/v0.1.0/completed.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:b9efa353c4f803a946be988b669b8f5ffa69ed234d8f39c7a20a9902aaef06c7",
+  "receipt_digest": "sha256:75e6a9d03af36f7306e2bd0e56d3d2d217eb662ae6683d525c06c4d021a66c9e",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
     "terminal_status": "completed",
@@ -34,8 +34,8 @@
         "approval": {
           "approval_id": "approval-001",
           "actor_id": "maintainer-001",
-          "scope": "plan",
-          "subject_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "scope": "subject",
+          "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "evidence": {
             "evidence_type": "approval",
             "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -79,9 +79,22 @@
         ]
       },
       {
-        "event_type": "mutation",
+        "event_type": "protected_effect_decision",
         "sequence": 7,
-        "decision_id": "decision-tool-001",
+        "decision_id": "decision-mutation-001",
+        "gate": "workflow",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "decision": {
+          "outcome": "allow",
+          "code": "workflow.mutation_authorized",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "mutation",
+        "sequence": 8,
+        "decision_id": "decision-mutation-001",
         "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
         "before_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "after_subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -95,7 +108,7 @@
       },
       {
         "event_type": "usage",
-        "sequence": 8,
+        "sequence": 9,
         "usage": {
           "cost_micros": 200000,
           "elapsed_ms": 2000,
@@ -105,14 +118,14 @@
       },
       {
         "event_type": "status_transition",
-        "sequence": 9,
+        "sequence": 10,
         "from": "executing",
         "to": "verifying",
         "reason": null
       },
       {
         "event_type": "verification",
-        "sequence": 10,
+        "sequence": 11,
         "subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "implementer_id": "executor-001",
         "verifier_id": "verifier-001",
@@ -132,7 +145,7 @@
       },
       {
         "event_type": "protected_effect_decision",
-        "sequence": 11,
+        "sequence": 12,
         "decision_id": "decision-completion-001",
         "gate": "workflow",
         "protected_effect_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -147,7 +160,7 @@
       },
       {
         "event_type": "status_transition",
-        "sequence": 12,
+        "sequence": 13,
         "from": "verifying",
         "to": "completed",
         "reason": "workflow.completion_authorized"

--- a/examples/contracts/v0.1.0/denied-effect.json
+++ b/examples/contracts/v0.1.0/denied-effect.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:2eb68806fc04632bbe65e2cf9b08613cc461fda085766a6a6c07283b796fe0e7",
+  "receipt_digest": "sha256:2f5fd610951863e98b83a825033558d2603cf23ad212fc9cabae14ad8882f4e1",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "terminal_status": "blocked",

--- a/examples/contracts/v0.1.0/denied-effect.json
+++ b/examples/contracts/v0.1.0/denied-effect.json
@@ -1,0 +1,65 @@
+{
+  "receipt_digest": "sha256:2eb68806fc04632bbe65e2cf9b08613cc461fda085766a6a6c07283b796fe0e7",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "terminal_status": "blocked",
+    "terminal_reason": "permission.denied",
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 2,
+        "from": "planning",
+        "to": "executing",
+        "reason": null
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 3,
+        "decision_id": "decision-denied-001",
+        "gate": "permission",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "decision": {
+          "outcome": "block",
+          "code": "permission.denied",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "usage",
+        "sequence": 4,
+        "usage": {
+          "cost_micros": 0,
+          "elapsed_ms": 0,
+          "model_tokens": 0,
+          "tool_calls": 0
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 5,
+        "from": "executing",
+        "to": "blocked",
+        "reason": "permission.denied"
+      }
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/failed.json
+++ b/examples/contracts/v0.1.0/failed.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:e0bedaff33342873738f5d6de9114d7576070a450e06f6a297fe142182750920",
+  "receipt_digest": "sha256:5693ebdef63f3f16acd159d7aa571f3890164626ba743db2a4f8804d99dc236c",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "terminal_status": "failed",

--- a/examples/contracts/v0.1.0/failed.json
+++ b/examples/contracts/v0.1.0/failed.json
@@ -1,0 +1,45 @@
+{
+  "receipt_digest": "sha256:e0bedaff33342873738f5d6de9114d7576070a450e06f6a297fe142182750920",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "terminal_status": "failed",
+    "terminal_reason": "execution.failed",
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "usage",
+        "sequence": 2,
+        "usage": {
+          "cost_micros": 0,
+          "elapsed_ms": 0,
+          "model_tokens": 0,
+          "tool_calls": 0
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 3,
+        "from": "planning",
+        "to": "failed",
+        "reason": "execution.failed"
+      }
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/interrupted.json
+++ b/examples/contracts/v0.1.0/interrupted.json
@@ -1,0 +1,56 @@
+{
+  "receipt_digest": "sha256:d1ec563de08693b645c2a4bfb94302a8f13b364cea881f46e721fc7d7168219c",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "terminal_status": "interrupted",
+    "terminal_reason": "operator.interrupted",
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "interruption",
+        "sequence": 2,
+        "actor_id": "operator-001",
+        "reason": "operator.interrupted",
+        "evidence": {
+          "evidence_type": "interruption",
+          "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "locator": null
+        }
+      },
+      {
+        "event_type": "usage",
+        "sequence": 3,
+        "usage": {
+          "cost_micros": 0,
+          "elapsed_ms": 0,
+          "model_tokens": 0,
+          "tool_calls": 0
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 4,
+        "from": "planning",
+        "to": "interrupted",
+        "reason": "operator.interrupted"
+      }
+    ]
+  }
+}

--- a/examples/contracts/v0.1.0/interrupted.json
+++ b/examples/contracts/v0.1.0/interrupted.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:d1ec563de08693b645c2a4bfb94302a8f13b364cea881f46e721fc7d7168219c",
+  "receipt_digest": "sha256:b9e3207978a4ff265fdd603fcce9a113aab16505772e9982386feaeeeb5b5849",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "terminal_status": "interrupted",

--- a/examples/contracts/v0.1.0/stale-verification.json
+++ b/examples/contracts/v0.1.0/stale-verification.json
@@ -1,10 +1,10 @@
 {
-  "receipt_digest": "sha256:bb9bb80e0fe4604ce9f0c3ea7e027b5ff63506482d58bcef6ffa96338646a506",
+  "receipt_digest": "sha256:6e87aa7f72bcb11960af6e6c9591f2f93e1d676ab68d0a1251479da81dca75cb",
   "body": {
     "schema_version": "gaap.terminal-run-receipt/0.1.0",
     "request_id": "request-001",
     "run_id": "run-001",
-    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
     "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "resulting_subject_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
     "terminal_status": "blocked",
@@ -34,8 +34,8 @@
         "approval": {
           "approval_id": "approval-001",
           "actor_id": "maintainer-001",
-          "scope": "plan",
-          "subject_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "scope": "subject",
+          "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "evidence": {
             "evidence_type": "approval",
             "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -54,12 +54,12 @@
         "event_type": "protected_effect_decision",
         "sequence": 5,
         "decision_id": "decision-mutation-001",
-        "gate": "permission",
+        "gate": "workflow",
         "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
         "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "decision": {
           "outcome": "allow",
-          "code": "permission.policy_allowed",
+          "code": "workflow.mutation_authorized",
           "effects": []
         }
       },
@@ -116,12 +116,12 @@
         "event_type": "protected_effect_decision",
         "sequence": 10,
         "decision_id": "decision-mutation-002",
-        "gate": "permission",
+        "gate": "workflow",
         "protected_effect_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
         "subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "decision": {
           "outcome": "allow",
-          "code": "permission.policy_allowed",
+          "code": "workflow.mutation_authorized",
           "effects": []
         }
       },

--- a/examples/contracts/v0.1.0/stale-verification.json
+++ b/examples/contracts/v0.1.0/stale-verification.json
@@ -1,0 +1,162 @@
+{
+  "receipt_digest": "sha256:bb9bb80e0fe4604ce9f0c3ea7e027b5ff63506482d58bcef6ffa96338646a506",
+  "body": {
+    "schema_version": "gaap.terminal-run-receipt/0.1.0",
+    "request_id": "request-001",
+    "run_id": "run-001",
+    "request_digest": "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632",
+    "initial_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resulting_subject_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "terminal_status": "blocked",
+    "terminal_reason": "verification.stale_subject",
+    "usage": {
+      "cost_micros": 200000,
+      "elapsed_ms": 2000,
+      "model_tokens": 2500,
+      "tool_calls": 1
+    },
+    "events": [
+      {
+        "event_type": "status_transition",
+        "sequence": 1,
+        "from": "accepted",
+        "to": "planning",
+        "reason": null
+      },
+      {
+        "event_type": "plan_recorded",
+        "sequence": 2,
+        "plan_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      {
+        "event_type": "approval_recorded",
+        "sequence": 3,
+        "approval": {
+          "approval_id": "approval-001",
+          "actor_id": "maintainer-001",
+          "scope": "plan",
+          "subject_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "evidence": {
+            "evidence_type": "approval",
+            "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "locator": null
+          }
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 4,
+        "from": "planning",
+        "to": "executing",
+        "reason": null
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 5,
+        "decision_id": "decision-mutation-001",
+        "gate": "permission",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "decision": {
+          "outcome": "allow",
+          "code": "permission.policy_allowed",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "mutation",
+        "sequence": 6,
+        "decision_id": "decision-mutation-001",
+        "protected_effect_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "before_subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "after_subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "evidence": [
+          {
+            "evidence_type": "artifact",
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "locator": null
+          }
+        ]
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 7,
+        "from": "executing",
+        "to": "verifying",
+        "reason": null
+      },
+      {
+        "event_type": "verification",
+        "sequence": 8,
+        "subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "implementer_id": "executor-001",
+        "verifier_id": "verifier-001",
+        "verdict": "PASS",
+        "evidence": [
+          {
+            "evidence_type": "command_output",
+            "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "locator": null
+          },
+          {
+            "evidence_type": "artifact",
+            "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            "locator": null
+          }
+        ]
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 9,
+        "from": "verifying",
+        "to": "executing",
+        "reason": null
+      },
+      {
+        "event_type": "protected_effect_decision",
+        "sequence": 10,
+        "decision_id": "decision-mutation-002",
+        "gate": "permission",
+        "protected_effect_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "decision": {
+          "outcome": "allow",
+          "code": "permission.policy_allowed",
+          "effects": []
+        }
+      },
+      {
+        "event_type": "mutation",
+        "sequence": 11,
+        "decision_id": "decision-mutation-002",
+        "protected_effect_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "before_subject_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "after_subject_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "evidence": [
+          {
+            "evidence_type": "artifact",
+            "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+            "locator": null
+          }
+        ]
+      },
+      {
+        "event_type": "usage",
+        "sequence": 12,
+        "usage": {
+          "cost_micros": 200000,
+          "elapsed_ms": 2000,
+          "model_tokens": 2500,
+          "tool_calls": 1
+        }
+      },
+      {
+        "event_type": "status_transition",
+        "sequence": 13,
+        "from": "executing",
+        "to": "blocked",
+        "reason": "verification.stale_subject"
+      }
+    ]
+  }
+}

--- a/examples/generate-contract-examples.rs
+++ b/examples/generate-contract-examples.rs
@@ -131,8 +131,8 @@ fn approval() -> ApprovalReference {
     ApprovalReference {
         approval_id: "approval-001".to_owned(),
         actor_id: "maintainer-001".to_owned(),
-        scope: "plan".to_owned(),
-        subject_digest: digest('d'),
+        scope: "subject".to_owned(),
+        subject_digest: digest('a'),
         evidence: evidence(EvidenceType::Approval, 'e'),
     }
 }
@@ -310,26 +310,35 @@ fn completed(
                     capability_digest: digest('c'),
                     evidence: vec![evidence(EvidenceType::ToolExecution, '9')],
                 },
+                decision(
+                    7,
+                    "decision-mutation-001",
+                    Gate::Workflow,
+                    effect.clone(),
+                    initial.clone(),
+                    Outcome::Allow,
+                    "workflow.mutation_authorized",
+                ),
                 RunEvent::Mutation {
-                    sequence: 7,
-                    decision_id: "decision-tool-001".to_owned(),
+                    sequence: 8,
+                    decision_id: "decision-mutation-001".to_owned(),
                     protected_effect_digest: effect,
                     before_subject_digest: initial,
                     after_subject_digest: resulting.clone(),
                     evidence: vec![evidence(EvidenceType::Artifact, '0')],
                 },
                 RunEvent::Usage {
-                    sequence: 8,
+                    sequence: 9,
                     usage: final_usage,
                 },
                 status(
-                    9,
+                    10,
                     AgentRunStatus::Executing,
                     AgentRunStatus::Verifying,
                     None,
                 ),
                 RunEvent::Verification {
-                    sequence: 10,
+                    sequence: 11,
                     subject_digest: resulting.clone(),
                     implementer_id: "executor-001".to_owned(),
                     verifier_id: "verifier-001".to_owned(),
@@ -340,7 +349,7 @@ fn completed(
                     ],
                 },
                 RunEvent::ProtectedEffectDecision {
-                    sequence: 11,
+                    sequence: 12,
                     decision_id: "decision-completion-001".to_owned(),
                     gate: Gate::Workflow,
                     protected_effect_digest: resulting.clone(),
@@ -352,7 +361,7 @@ fn completed(
                     },
                 },
                 status(
-                    12,
+                    13,
                     AgentRunStatus::Verifying,
                     AgentRunStatus::Completed,
                     Some("workflow.completion_authorized"),
@@ -602,11 +611,11 @@ fn stale_verification(
                 decision(
                     5,
                     "decision-mutation-001",
-                    Gate::Permission,
+                    Gate::Workflow,
                     first_effect.clone(),
                     initial.clone(),
                     Outcome::Allow,
-                    "permission.policy_allowed",
+                    "workflow.mutation_authorized",
                 ),
                 RunEvent::Mutation {
                     sequence: 6,
@@ -642,11 +651,11 @@ fn stale_verification(
                 decision(
                     10,
                     "decision-mutation-002",
-                    Gate::Permission,
+                    Gate::Workflow,
                     second_effect.clone(),
                     verified.clone(),
                     Outcome::Allow,
-                    "permission.policy_allowed",
+                    "workflow.mutation_authorized",
                 ),
                 RunEvent::Mutation {
                     sequence: 11,

--- a/examples/generate-contract-examples.rs
+++ b/examples/generate-contract-examples.rs
@@ -1,0 +1,672 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use gaap::contracts::{
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, AgentRunStatus, ApprovalReference,
+    CapabilityIdentity, ContractSupport, EvidenceReference, EvidenceType, PolicyIdentity,
+    ResourceBudget, ResourceUsage, RunEvent, Subject, SubjectKind, TERMINAL_RUN_RECEIPT_SCHEMA,
+    TaskSpec, TerminalRunReceipt, TerminalRunReceiptBody, VerificationIndependence,
+    VerificationRequirement, VerificationVerdict, seal_terminal_receipt, validate_request,
+    verify_terminal_receipt,
+};
+use gaap::{Decision, Gate, Outcome};
+use serde::Serialize;
+
+const DIRECTORY: &str = "examples/contracts/v0.1.0";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("contract example generation failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let arguments: Vec<String> = env::args().skip(1).collect();
+    let check = match arguments.as_slice() {
+        [] => false,
+        [argument] if argument == "--check" => true,
+        _ => {
+            return Err(
+                "usage: cargo run --locked --example generate-contract-examples -- [--check]"
+                    .to_owned(),
+            );
+        }
+    };
+
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).map_err(|error| error.to_string())?;
+    let receipts = [
+        (
+            "completed.json",
+            completed(&request, &support, &request_digest)?,
+        ),
+        (
+            "blocked.json",
+            blocked(&request, &support, &request_digest)?,
+        ),
+        ("failed.json", failed(&request, &support, &request_digest)?),
+        (
+            "interrupted.json",
+            interrupted(&request, &support, &request_digest)?,
+        ),
+        (
+            "budget-exhausted.json",
+            budget_exhausted(&request, &support, &request_digest)?,
+        ),
+        (
+            "denied-effect.json",
+            denied_effect(&request, &support, &request_digest)?,
+        ),
+        (
+            "stale-verification.json",
+            stale_verification(&request, &support, &request_digest)?,
+        ),
+    ];
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    materialize(&root, "agent-run-request.json", &request, check)?;
+    for (file_name, receipt) in receipts {
+        verify_terminal_receipt(&request, &support, &receipt)
+            .map_err(|error| format!("{file_name} does not verify: {error}"))?;
+        materialize(&root, file_name, &receipt, check)?;
+    }
+    Ok(())
+}
+
+fn materialize<T: Serialize>(
+    root: &Path,
+    file_name: &str,
+    value: &T,
+    check: bool,
+) -> Result<(), String> {
+    let relative_path = format!("{DIRECTORY}/{file_name}");
+    let path = root.join(&relative_path);
+    let contents = format!(
+        "{}\n",
+        serde_json::to_string_pretty(value)
+            .map_err(|error| format!("could not serialize {relative_path}: {error}"))?
+    );
+    if check {
+        let actual = fs::read_to_string(&path)
+            .map_err(|error| format!("could not read {relative_path}: {error}"))?;
+        if actual != contents {
+            return Err(format!(
+                "{relative_path} is stale; run `cargo run --locked --example generate-contract-examples`"
+            ));
+        }
+        println!("example is current: {relative_path}");
+    } else {
+        let parent = path
+            .parent()
+            .ok_or_else(|| format!("example path has no parent: {relative_path}"))?;
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+        fs::write(&path, contents)
+            .map_err(|error| format!("could not write {relative_path}: {error}"))?;
+        println!("wrote example: {relative_path}");
+    }
+    Ok(())
+}
+
+fn digest(byte: char) -> String {
+    format!("sha256:{}", byte.to_string().repeat(64))
+}
+
+fn policy() -> PolicyIdentity {
+    PolicyIdentity {
+        name: "gaap.run-coordinator".to_owned(),
+        version: "0.1.0".to_owned(),
+        digest: digest('b'),
+    }
+}
+
+fn approval() -> ApprovalReference {
+    ApprovalReference {
+        approval_id: "approval-001".to_owned(),
+        actor_id: "maintainer-001".to_owned(),
+        scope: "plan".to_owned(),
+        subject_digest: digest('d'),
+        evidence: evidence(EvidenceType::Approval, 'e'),
+    }
+}
+
+fn evidence(evidence_type: EvidenceType, byte: char) -> EvidenceReference {
+    EvidenceReference {
+        evidence_type,
+        digest: digest(byte),
+        locator: None,
+    }
+}
+
+fn request() -> AgentRunRequest {
+    AgentRunRequest {
+        schema_version: AGENT_RUN_REQUEST_SCHEMA.to_owned(),
+        request_id: "request-001".to_owned(),
+        run_id: "run-001".to_owned(),
+        subject: Subject {
+            kind: SubjectKind::Repository,
+            locator: "https://example.invalid/repository".to_owned(),
+            digest: digest('a'),
+        },
+        requested_capability: CapabilityIdentity {
+            name: "change-code".to_owned(),
+            version: "1".to_owned(),
+            digest: digest('c'),
+        },
+        task: TaskSpec {
+            instructions: "Implement the approved change.".to_owned(),
+            constraints: vec!["Do not publish a release.".to_owned()],
+        },
+        policies: vec![policy()],
+        resource_budget: ResourceBudget {
+            max_cost_micros: 1_000_000,
+            max_elapsed_ms: 60_000,
+            max_model_tokens: 100_000,
+            max_tool_calls: 100,
+        },
+        approval_context: vec![approval()],
+        required_verification: VerificationRequirement {
+            independence: VerificationIndependence::DifferentActor,
+            evidence_types: vec![EvidenceType::CommandOutput, EvidenceType::Artifact],
+        },
+    }
+}
+
+fn usage() -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: 200_000,
+        elapsed_ms: 2_000,
+        model_tokens: 2_500,
+        tool_calls: 1,
+    }
+}
+
+fn zero_usage() -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: 0,
+        elapsed_ms: 0,
+        model_tokens: 0,
+        tool_calls: 0,
+    }
+}
+
+fn status(
+    sequence: u64,
+    from: AgentRunStatus,
+    to: AgentRunStatus,
+    reason: Option<&str>,
+) -> RunEvent {
+    RunEvent::StatusTransition {
+        sequence,
+        from,
+        to,
+        reason: reason.map(str::to_owned),
+    }
+}
+
+fn decision(
+    sequence: u64,
+    decision_id: &str,
+    gate: Gate,
+    protected_effect_digest: String,
+    subject_digest: String,
+    outcome: Outcome,
+    code: &str,
+) -> RunEvent {
+    RunEvent::ProtectedEffectDecision {
+        sequence,
+        decision_id: decision_id.to_owned(),
+        gate,
+        protected_effect_digest,
+        subject_digest,
+        decision: Decision {
+            outcome,
+            code: code.to_owned(),
+            effects: vec![],
+        },
+    }
+}
+
+fn body(
+    request_digest: &str,
+    resulting_subject_digest: String,
+    terminal_status: AgentRunStatus,
+    terminal_reason: &str,
+    usage: ResourceUsage,
+    events: Vec<RunEvent>,
+) -> TerminalRunReceiptBody {
+    TerminalRunReceiptBody {
+        schema_version: TERMINAL_RUN_RECEIPT_SCHEMA.to_owned(),
+        request_id: "request-001".to_owned(),
+        run_id: "run-001".to_owned(),
+        request_digest: request_digest.to_owned(),
+        initial_subject_digest: digest('a'),
+        resulting_subject_digest,
+        terminal_status,
+        terminal_reason: terminal_reason.to_owned(),
+        usage,
+        events,
+    }
+}
+
+fn seal(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    body: TerminalRunReceiptBody,
+) -> Result<TerminalRunReceipt, String> {
+    seal_terminal_receipt(request, support, body).map_err(|error| error.to_string())
+}
+
+fn completed(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    let initial = digest('a');
+    let resulting = digest('f');
+    let effect = digest('7');
+    let final_usage = usage();
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            resulting.clone(),
+            AgentRunStatus::Completed,
+            "workflow.completion_authorized",
+            final_usage.clone(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                RunEvent::PlanRecorded {
+                    sequence: 2,
+                    plan_digest: digest('d'),
+                },
+                RunEvent::ApprovalRecorded {
+                    sequence: 3,
+                    approval: approval(),
+                },
+                status(4, AgentRunStatus::Planning, AgentRunStatus::Executing, None),
+                decision(
+                    5,
+                    "decision-tool-001",
+                    Gate::Permission,
+                    effect.clone(),
+                    initial.clone(),
+                    Outcome::Allow,
+                    "permission.policy_allowed",
+                ),
+                RunEvent::ToolExecution {
+                    sequence: 6,
+                    decision_id: "decision-tool-001".to_owned(),
+                    protected_effect_digest: effect.clone(),
+                    action_digest: digest('8'),
+                    capability_digest: digest('c'),
+                    evidence: vec![evidence(EvidenceType::ToolExecution, '9')],
+                },
+                RunEvent::Mutation {
+                    sequence: 7,
+                    decision_id: "decision-tool-001".to_owned(),
+                    protected_effect_digest: effect,
+                    before_subject_digest: initial,
+                    after_subject_digest: resulting.clone(),
+                    evidence: vec![evidence(EvidenceType::Artifact, '0')],
+                },
+                RunEvent::Usage {
+                    sequence: 8,
+                    usage: final_usage,
+                },
+                status(
+                    9,
+                    AgentRunStatus::Executing,
+                    AgentRunStatus::Verifying,
+                    None,
+                ),
+                RunEvent::Verification {
+                    sequence: 10,
+                    subject_digest: resulting.clone(),
+                    implementer_id: "executor-001".to_owned(),
+                    verifier_id: "verifier-001".to_owned(),
+                    verdict: VerificationVerdict::Pass,
+                    evidence: vec![
+                        evidence(EvidenceType::CommandOutput, '1'),
+                        evidence(EvidenceType::Artifact, '2'),
+                    ],
+                },
+                RunEvent::ProtectedEffectDecision {
+                    sequence: 11,
+                    decision_id: "decision-completion-001".to_owned(),
+                    gate: Gate::Workflow,
+                    protected_effect_digest: resulting.clone(),
+                    subject_digest: resulting,
+                    decision: Decision {
+                        outcome: Outcome::Allow,
+                        code: "workflow.completion_authorized".to_owned(),
+                        effects: vec!["record_completion".to_owned()],
+                    },
+                },
+                status(
+                    12,
+                    AgentRunStatus::Verifying,
+                    AgentRunStatus::Completed,
+                    Some("workflow.completion_authorized"),
+                ),
+            ],
+        ),
+    )
+}
+
+fn blocked(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    let initial = digest('a');
+    let effect = digest('7');
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            initial.clone(),
+            AgentRunStatus::Blocked,
+            "authority.required",
+            zero_usage(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                decision(
+                    2,
+                    "decision-authority-001",
+                    Gate::Permission,
+                    effect,
+                    initial,
+                    Outcome::Ask,
+                    "permission.policy_requires_approval",
+                ),
+                status(
+                    3,
+                    AgentRunStatus::Planning,
+                    AgentRunStatus::AwaitingAuthority,
+                    Some("authority.required"),
+                ),
+                RunEvent::Usage {
+                    sequence: 4,
+                    usage: zero_usage(),
+                },
+                status(
+                    5,
+                    AgentRunStatus::AwaitingAuthority,
+                    AgentRunStatus::Blocked,
+                    Some("authority.required"),
+                ),
+            ],
+        ),
+    )
+}
+
+fn failed(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            digest('a'),
+            AgentRunStatus::Failed,
+            "execution.failed",
+            zero_usage(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                RunEvent::Usage {
+                    sequence: 2,
+                    usage: zero_usage(),
+                },
+                status(
+                    3,
+                    AgentRunStatus::Planning,
+                    AgentRunStatus::Failed,
+                    Some("execution.failed"),
+                ),
+            ],
+        ),
+    )
+}
+
+fn interrupted(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            digest('a'),
+            AgentRunStatus::Interrupted,
+            "operator.interrupted",
+            zero_usage(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                RunEvent::Interruption {
+                    sequence: 2,
+                    actor_id: Some("operator-001".to_owned()),
+                    reason: "operator.interrupted".to_owned(),
+                    evidence: evidence(EvidenceType::Interruption, '4'),
+                },
+                RunEvent::Usage {
+                    sequence: 3,
+                    usage: zero_usage(),
+                },
+                status(
+                    4,
+                    AgentRunStatus::Planning,
+                    AgentRunStatus::Interrupted,
+                    Some("operator.interrupted"),
+                ),
+            ],
+        ),
+    )
+}
+
+fn budget_exhausted(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    let initial = digest('a');
+    let final_usage = ResourceUsage {
+        cost_micros: request.resource_budget.max_cost_micros,
+        elapsed_ms: request.resource_budget.max_elapsed_ms,
+        model_tokens: request.resource_budget.max_model_tokens,
+        tool_calls: request.resource_budget.max_tool_calls,
+    };
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            initial.clone(),
+            AgentRunStatus::Blocked,
+            "runtime.hard_stop",
+            final_usage.clone(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                status(2, AgentRunStatus::Planning, AgentRunStatus::Executing, None),
+                decision(
+                    3,
+                    "decision-budget-001",
+                    Gate::Runtime,
+                    digest('7'),
+                    initial,
+                    Outcome::Block,
+                    "runtime.hard_stop",
+                ),
+                RunEvent::Usage {
+                    sequence: 4,
+                    usage: final_usage,
+                },
+                status(
+                    5,
+                    AgentRunStatus::Executing,
+                    AgentRunStatus::Blocked,
+                    Some("runtime.hard_stop"),
+                ),
+            ],
+        ),
+    )
+}
+
+fn denied_effect(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    let initial = digest('a');
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            initial.clone(),
+            AgentRunStatus::Blocked,
+            "permission.denied",
+            zero_usage(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                status(2, AgentRunStatus::Planning, AgentRunStatus::Executing, None),
+                decision(
+                    3,
+                    "decision-denied-001",
+                    Gate::Permission,
+                    digest('7'),
+                    initial,
+                    Outcome::Block,
+                    "permission.denied",
+                ),
+                RunEvent::Usage {
+                    sequence: 4,
+                    usage: zero_usage(),
+                },
+                status(
+                    5,
+                    AgentRunStatus::Executing,
+                    AgentRunStatus::Blocked,
+                    Some("permission.denied"),
+                ),
+            ],
+        ),
+    )
+}
+
+fn stale_verification(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    request_digest: &str,
+) -> Result<TerminalRunReceipt, String> {
+    let initial = digest('a');
+    let verified = digest('f');
+    let resulting = digest('6');
+    let first_effect = digest('7');
+    let second_effect = digest('5');
+    let final_usage = usage();
+    seal(
+        request,
+        support,
+        body(
+            request_digest,
+            resulting.clone(),
+            AgentRunStatus::Blocked,
+            "verification.stale_subject",
+            final_usage.clone(),
+            vec![
+                status(1, AgentRunStatus::Accepted, AgentRunStatus::Planning, None),
+                RunEvent::PlanRecorded {
+                    sequence: 2,
+                    plan_digest: digest('d'),
+                },
+                RunEvent::ApprovalRecorded {
+                    sequence: 3,
+                    approval: approval(),
+                },
+                status(4, AgentRunStatus::Planning, AgentRunStatus::Executing, None),
+                decision(
+                    5,
+                    "decision-mutation-001",
+                    Gate::Permission,
+                    first_effect.clone(),
+                    initial.clone(),
+                    Outcome::Allow,
+                    "permission.policy_allowed",
+                ),
+                RunEvent::Mutation {
+                    sequence: 6,
+                    decision_id: "decision-mutation-001".to_owned(),
+                    protected_effect_digest: first_effect,
+                    before_subject_digest: initial,
+                    after_subject_digest: verified.clone(),
+                    evidence: vec![evidence(EvidenceType::Artifact, '0')],
+                },
+                status(
+                    7,
+                    AgentRunStatus::Executing,
+                    AgentRunStatus::Verifying,
+                    None,
+                ),
+                RunEvent::Verification {
+                    sequence: 8,
+                    subject_digest: verified.clone(),
+                    implementer_id: "executor-001".to_owned(),
+                    verifier_id: "verifier-001".to_owned(),
+                    verdict: VerificationVerdict::Pass,
+                    evidence: vec![
+                        evidence(EvidenceType::CommandOutput, '1'),
+                        evidence(EvidenceType::Artifact, '2'),
+                    ],
+                },
+                status(
+                    9,
+                    AgentRunStatus::Verifying,
+                    AgentRunStatus::Executing,
+                    None,
+                ),
+                decision(
+                    10,
+                    "decision-mutation-002",
+                    Gate::Permission,
+                    second_effect.clone(),
+                    verified.clone(),
+                    Outcome::Allow,
+                    "permission.policy_allowed",
+                ),
+                RunEvent::Mutation {
+                    sequence: 11,
+                    decision_id: "decision-mutation-002".to_owned(),
+                    protected_effect_digest: second_effect,
+                    before_subject_digest: verified,
+                    after_subject_digest: resulting,
+                    evidence: vec![evidence(EvidenceType::Artifact, '3')],
+                },
+                RunEvent::Usage {
+                    sequence: 12,
+                    usage: final_usage,
+                },
+                status(
+                    13,
+                    AgentRunStatus::Executing,
+                    AgentRunStatus::Blocked,
+                    Some("verification.stale_subject"),
+                ),
+            ],
+        ),
+    )
+}

--- a/examples/generate-contract-schemas.rs
+++ b/examples/generate-contract-schemas.rs
@@ -1,0 +1,76 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use gaap::contracts::{agent_run_request_schema, terminal_run_receipt_schema};
+
+const REQUEST_PATH: &str = "schemas/agent-run/v0.1.0/agent-run-request.schema.json";
+const RECEIPT_PATH: &str = "schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("schema generation failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let arguments: Vec<String> = env::args().skip(1).collect();
+    let check = match arguments.as_slice() {
+        [] => false,
+        [argument] if argument == "--check" => true,
+        _ => {
+            return Err(
+                "usage: cargo run --locked --example generate-contract-schemas -- [--check]"
+                    .to_owned(),
+            );
+        }
+    };
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let schemas = [
+        (REQUEST_PATH, agent_run_request_schema()),
+        (RECEIPT_PATH, terminal_run_receipt_schema()),
+    ];
+    for (relative_path, schema) in schemas {
+        let path = root.join(relative_path);
+        let contents = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&schema)
+                .map_err(|error| format!("could not serialize {relative_path}: {error}"))?
+        );
+        if check {
+            check_schema(&path, relative_path, &contents)?;
+        } else {
+            write_schema(&path, relative_path, &contents)?;
+        }
+    }
+    Ok(())
+}
+
+fn check_schema(path: &Path, relative_path: &str, expected: &str) -> Result<(), String> {
+    let actual = fs::read_to_string(path)
+        .map_err(|error| format!("could not read {relative_path}: {error}"))?;
+    if actual != expected {
+        return Err(format!(
+            "{relative_path} is stale; run `cargo run --locked --example generate-contract-schemas`"
+        ));
+    }
+    println!("schema is current: {relative_path}");
+    Ok(())
+}
+
+fn write_schema(path: &Path, relative_path: &str, contents: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("schema path has no parent: {relative_path}"))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    fs::write(path, contents)
+        .map_err(|error| format!("could not write {relative_path}: {error}"))?;
+    println!("wrote schema: {relative_path}");
+    Ok(())
+}

--- a/schemas/agent-run/v0.1.0/agent-run-request.schema.json
+++ b/schemas/agent-run/v0.1.0/agent-run-request.schema.json
@@ -1,0 +1,300 @@
+{
+  "$defs": {
+    "ApprovalReference": {
+      "additionalProperties": false,
+      "description": "Existing approval evidence bound to an actor, scope, and exact subject.",
+      "properties": {
+        "actor_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "approval_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/EvidenceReference"
+        },
+        "scope": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "subject_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "approval_id",
+        "actor_id",
+        "scope",
+        "subject_digest",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "CapabilityIdentity": {
+      "additionalProperties": false,
+      "description": "Requested engineering capability bound to its versioned content digest.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "EvidenceReference": {
+      "additionalProperties": false,
+      "description": "Content-addressed evidence metadata; raw evidence remains external.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "evidence_type": {
+          "$ref": "#/$defs/EvidenceType"
+        },
+        "locator": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "evidence_type",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "EvidenceType": {
+      "description": "Closed evidence categories supported by contract version 0.1.0.",
+      "enum": [
+        "approval",
+        "command_output",
+        "artifact",
+        "tool_execution",
+        "verification_attestation",
+        "resource_usage",
+        "interruption"
+      ],
+      "type": "string"
+    },
+    "PolicyIdentity": {
+      "additionalProperties": false,
+      "description": "Exact policy identity accepted by a caller's [`super::ContractSupport`].",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "ResourceBudget": {
+      "additionalProperties": false,
+      "description": "Upper bounds declared for one Agent Run.",
+      "properties": {
+        "max_cost_micros": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "max_elapsed_ms": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "max_model_tokens": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "max_tool_calls": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "max_cost_micros",
+        "max_elapsed_ms",
+        "max_model_tokens",
+        "max_tool_calls"
+      ],
+      "type": "object"
+    },
+    "Subject": {
+      "additionalProperties": false,
+      "description": "Exact repository or artifact that the Agent Run may inspect or change.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/SubjectKind"
+        },
+        "locator": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "locator",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "SubjectKind": {
+      "description": "Closed subject categories supported by contract version 0.1.0.",
+      "enum": [
+        "repository",
+        "artifact"
+      ],
+      "type": "string"
+    },
+    "TaskSpec": {
+      "additionalProperties": false,
+      "description": "Self-contained task instructions and ordered textual constraints.",
+      "properties": {
+        "constraints": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "instructions": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "instructions",
+        "constraints"
+      ],
+      "type": "object"
+    },
+    "VerificationIndependence": {
+      "description": "Actor-separation rules supported by contract version 0.1.0.",
+      "enum": [
+        "different_actor"
+      ],
+      "type": "string"
+    },
+    "VerificationRequirement": {
+      "additionalProperties": false,
+      "description": "Independent evidence required before an Agent Run may complete.",
+      "properties": {
+        "evidence_types": {
+          "items": {
+            "$ref": "#/$defs/EvidenceType"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "independence": {
+          "$ref": "#/$defs/VerificationIndependence"
+        }
+      },
+      "required": [
+        "independence",
+        "evidence_types"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/agent-run/v0.1.0/agent-run-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Immutable input that identifies one governed Agent Run.",
+  "properties": {
+    "approval_context": {
+      "items": {
+        "$ref": "#/$defs/ApprovalReference"
+      },
+      "type": "array"
+    },
+    "policies": {
+      "items": {
+        "$ref": "#/$defs/PolicyIdentity"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "request_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "requested_capability": {
+      "$ref": "#/$defs/CapabilityIdentity"
+    },
+    "required_verification": {
+      "$ref": "#/$defs/VerificationRequirement"
+    },
+    "resource_budget": {
+      "$ref": "#/$defs/ResourceBudget"
+    },
+    "run_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "gaap.agent-run-request/0.1.0",
+      "type": "string"
+    },
+    "subject": {
+      "$ref": "#/$defs/Subject"
+    },
+    "task": {
+      "$ref": "#/$defs/TaskSpec"
+    }
+  },
+  "required": [
+    "schema_version",
+    "request_id",
+    "run_id",
+    "subject",
+    "requested_capability",
+    "task",
+    "policies",
+    "resource_budget",
+    "approval_context",
+    "required_verification"
+  ],
+  "title": "GAAP Agent Run Request 0.1.0",
+  "type": "object"
+}

--- a/schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json
+++ b/schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json
@@ -1,0 +1,625 @@
+{
+  "$defs": {
+    "AgentRunStatus": {
+      "description": "Lifecycle states for one Agent Run, including four distinct terminal states.",
+      "enum": [
+        "accepted",
+        "planning",
+        "awaiting_authority",
+        "executing",
+        "verifying",
+        "completed",
+        "blocked",
+        "failed",
+        "interrupted"
+      ],
+      "type": "string"
+    },
+    "ApprovalReference": {
+      "additionalProperties": false,
+      "description": "Existing approval evidence bound to an actor, scope, and exact subject.",
+      "properties": {
+        "actor_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "approval_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/EvidenceReference"
+        },
+        "scope": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "subject_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "approval_id",
+        "actor_id",
+        "scope",
+        "subject_digest",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "Decision": {
+      "additionalProperties": false,
+      "description": "A normalized decision returned at a protected agent-run effect.",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "effects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "outcome": {
+          "$ref": "#/$defs/Outcome"
+        }
+      },
+      "required": [
+        "outcome",
+        "code",
+        "effects"
+      ],
+      "type": "object"
+    },
+    "EvidenceReference": {
+      "additionalProperties": false,
+      "description": "Content-addressed evidence metadata; raw evidence remains external.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "evidence_type": {
+          "$ref": "#/$defs/EvidenceType"
+        },
+        "locator": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "evidence_type",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "EvidenceType": {
+      "description": "Closed evidence categories supported by contract version 0.1.0.",
+      "enum": [
+        "approval",
+        "command_output",
+        "artifact",
+        "tool_execution",
+        "verification_attestation",
+        "resource_usage",
+        "interruption"
+      ],
+      "type": "string"
+    },
+    "Gate": {
+      "description": "A deterministic decision point owned by the run coordinator.",
+      "oneOf": [
+        {
+          "const": "plan",
+          "description": "Approval for the exact current plan before mutation.",
+          "type": "string"
+        },
+        {
+          "const": "permission",
+          "description": "Authority for a normalized action before execution.",
+          "type": "string"
+        },
+        {
+          "const": "tool_trust",
+          "description": "Approval for the exact capability before activation.",
+          "type": "string"
+        },
+        {
+          "const": "verification",
+          "description": "Independent evidence for the current subject before completion.",
+          "type": "string"
+        },
+        {
+          "const": "runtime",
+          "description": "Known usage and budget authority before budgeted execution.",
+          "type": "string"
+        },
+        {
+          "const": "workflow",
+          "description": "Aggregate authorization at mutation and completion transitions.",
+          "type": "string"
+        }
+      ]
+    },
+    "Outcome": {
+      "description": "The precedence-bearing result of an integrity decision.",
+      "oneOf": [
+        {
+          "const": "allow",
+          "description": "The protected effect may proceed.",
+          "type": "string"
+        },
+        {
+          "const": "ask",
+          "description": "The protected effect requires new authority before it may proceed.",
+          "type": "string"
+        },
+        {
+          "const": "block",
+          "description": "The protected effect must not proceed.",
+          "type": "string"
+        }
+      ]
+    },
+    "ResourceUsage": {
+      "additionalProperties": false,
+      "description": "Cumulative resource usage observed during one Agent Run.",
+      "properties": {
+        "cost_micros": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "elapsed_ms": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "model_tokens": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tool_calls": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cost_micros",
+        "elapsed_ms",
+        "model_tokens",
+        "tool_calls"
+      ],
+      "type": "object"
+    },
+    "RunEvent": {
+      "description": "One entry in the immutable, sequence-ordered Terminal Run Receipt ledger.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "event_type": {
+              "const": "status_transition",
+              "type": "string"
+            },
+            "from": {
+              "$ref": "#/$defs/AgentRunStatus"
+            },
+            "reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "to": {
+              "$ref": "#/$defs/AgentRunStatus"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "from",
+            "to"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "event_type": {
+              "const": "plan_recorded",
+              "type": "string"
+            },
+            "plan_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "plan_digest"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "approval": {
+              "$ref": "#/$defs/ApprovalReference"
+            },
+            "event_type": {
+              "const": "approval_recorded",
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "approval"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "decision": {
+              "$ref": "#/$defs/Decision"
+            },
+            "decision_id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "event_type": {
+              "const": "protected_effect_decision",
+              "type": "string"
+            },
+            "gate": {
+              "$ref": "#/$defs/Gate"
+            },
+            "protected_effect_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "subject_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "decision_id",
+            "gate",
+            "protected_effect_digest",
+            "subject_digest",
+            "decision"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "capability_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "decision_id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "event_type": {
+              "const": "tool_execution",
+              "type": "string"
+            },
+            "evidence": {
+              "items": {
+                "$ref": "#/$defs/EvidenceReference"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "protected_effect_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "decision_id",
+            "protected_effect_digest",
+            "action_digest",
+            "capability_digest",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "after_subject_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "before_subject_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "decision_id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "event_type": {
+              "const": "mutation",
+              "type": "string"
+            },
+            "evidence": {
+              "items": {
+                "$ref": "#/$defs/EvidenceReference"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "protected_effect_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "decision_id",
+            "protected_effect_digest",
+            "before_subject_digest",
+            "after_subject_digest",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "event_type": {
+              "const": "verification",
+              "type": "string"
+            },
+            "evidence": {
+              "items": {
+                "$ref": "#/$defs/EvidenceReference"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "implementer_id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "subject_digest": {
+              "pattern": "^sha256:[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "verdict": {
+              "$ref": "#/$defs/VerificationVerdict"
+            },
+            "verifier_id": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "subject_digest",
+            "implementer_id",
+            "verifier_id",
+            "verdict",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "event_type": {
+              "const": "usage",
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "usage": {
+              "$ref": "#/$defs/ResourceUsage"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "usage"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "actor_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "event_type": {
+              "const": "interruption",
+              "type": "string"
+            },
+            "evidence": {
+              "$ref": "#/$defs/EvidenceReference"
+            },
+            "reason": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sequence": {
+              "format": "uint64",
+              "maximum": 9007199254740991,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "event_type",
+            "sequence",
+            "reason",
+            "evidence"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "TerminalRunReceiptBody": {
+      "additionalProperties": false,
+      "description": "Canonical digest preimage containing the terminal Agent Run evidence.",
+      "properties": {
+        "events": {
+          "items": {
+            "$ref": "#/$defs/RunEvent"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "initial_subject_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "request_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "request_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "resulting_subject_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "run_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "gaap.terminal-run-receipt/0.1.0",
+          "type": "string"
+        },
+        "terminal_reason": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "terminal_status": {
+          "$ref": "#/$defs/AgentRunStatus"
+        },
+        "usage": {
+          "$ref": "#/$defs/ResourceUsage"
+        }
+      },
+      "required": [
+        "schema_version",
+        "request_id",
+        "run_id",
+        "request_digest",
+        "initial_subject_digest",
+        "resulting_subject_digest",
+        "terminal_status",
+        "terminal_reason",
+        "usage",
+        "events"
+      ],
+      "type": "object"
+    },
+    "VerificationVerdict": {
+      "description": "Independent verification result recorded in the receipt ledger.",
+      "enum": [
+        "PASS",
+        "FAIL"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Content-addressed envelope around a canonical Terminal Run Receipt body.",
+  "properties": {
+    "body": {
+      "$ref": "#/$defs/TerminalRunReceiptBody"
+    },
+    "receipt_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "receipt_digest",
+    "body"
+  ],
+  "title": "GAAP Terminal Run Receipt 0.1.0",
+  "type": "object"
+}

--- a/src/contracts/canonical.rs
+++ b/src/contracts/canonical.rs
@@ -1,11 +1,18 @@
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use super::model::AgentRunRequest;
+use super::model::{AgentRunRequest, TerminalRunReceiptBody};
 use super::validation::{ContractError, ContractErrorCode};
 
+/// Serialize an Agent Run Request using RFC 8785 JSON Canonicalization Scheme.
 pub fn canonical_request_bytes(request: &AgentRunRequest) -> Result<Vec<u8>, ContractError> {
     canonical_bytes(request)
+}
+
+pub(crate) fn canonical_receipt_body_bytes(
+    body: &TerminalRunReceiptBody,
+) -> Result<Vec<u8>, ContractError> {
+    canonical_bytes(body)
 }
 
 pub(crate) fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, ContractError> {

--- a/src/contracts/canonical.rs
+++ b/src/contracts/canonical.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::model::AgentRunRequest;
+use super::validation::{ContractError, ContractErrorCode};
+
+pub fn canonical_request_bytes(request: &AgentRunRequest) -> Result<Vec<u8>, ContractError> {
+    canonical_bytes(request)
+}
+
+pub(crate) fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, ContractError> {
+    serde_jcs::to_vec(value).map_err(|error| {
+        ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "$",
+            format!("could not canonicalize contract: {error}"),
+        )
+    })
+}
+
+pub(crate) fn sha256_digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}

--- a/src/contracts/canonical.rs
+++ b/src/contracts/canonical.rs
@@ -28,3 +28,33 @@ pub(crate) fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, Contra
 pub(crate) fn sha256_digest(bytes: &[u8]) -> String {
     format!("sha256:{:x}", Sha256::digest(bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::canonical_bytes;
+
+    #[test]
+    fn matches_the_rfc_8785_unicode_property_sorting_vector() {
+        let input: Value = serde_json::from_str(
+            r#"{
+                "\u20ac": "Euro Sign",
+                "\r": "Carriage Return",
+                "\ufb33": "Hebrew Letter Dalet With Dagesh",
+                "1": "One",
+                "\ud83d\ude00": "Emoji: Grinning Face",
+                "\u0080": "Control",
+                "\u00f6": "Latin Small Letter O With Diaeresis"
+            }"#,
+        )
+        .expect("RFC 8785 vector should parse");
+
+        let canonical = canonical_bytes(&input).expect("RFC 8785 vector should canonicalize");
+
+        assert_eq!(
+            String::from_utf8(canonical).expect("canonical JSON should be UTF-8"),
+            "{\"\\r\":\"Carriage Return\",\"1\":\"One\",\"\u{80}\":\"Control\",\"ö\":\"Latin Small Letter O With Diaeresis\",\"€\":\"Euro Sign\",\"😀\":\"Emoji: Grinning Face\",\"דּ\":\"Hebrew Letter Dalet With Dagesh\"}"
+        );
+    }
+}

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -1,0 +1,16 @@
+//! Versioned, provider-neutral contracts for one governed Agent Run.
+
+mod canonical;
+mod model;
+mod validation;
+
+pub use canonical::canonical_request_bytes;
+pub use model::{
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, ApprovalReference, CapabilityIdentity,
+    EvidenceReference, EvidenceType, PolicyIdentity, ResourceBudget, Subject, SubjectKind,
+    TaskSpec, VerificationIndependence, VerificationRequirement,
+};
+pub use validation::{
+    ContractError, ContractErrorCode, ContractSupport, parse_agent_run_request_json,
+    validate_request,
+};

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -2,15 +2,20 @@
 
 mod canonical;
 mod model;
+mod schema;
 mod validation;
 
 pub use canonical::canonical_request_bytes;
 pub use model::{
-    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, ApprovalReference, CapabilityIdentity,
-    EvidenceReference, EvidenceType, PolicyIdentity, ResourceBudget, Subject, SubjectKind,
-    TaskSpec, VerificationIndependence, VerificationRequirement,
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, AgentRunStatus, ApprovalReference,
+    CapabilityIdentity, EvidenceReference, EvidenceType, PolicyIdentity, ResourceBudget,
+    ResourceUsage, RunEvent, Subject, SubjectKind, TERMINAL_RUN_RECEIPT_SCHEMA, TaskSpec,
+    TerminalRunReceipt, TerminalRunReceiptBody, VerificationIndependence, VerificationRequirement,
+    VerificationVerdict,
 };
+pub use schema::{agent_run_request_schema, terminal_run_receipt_schema};
 pub use validation::{
     ContractError, ContractErrorCode, ContractSupport, parse_agent_run_request_json,
-    validate_request,
+    parse_terminal_run_receipt_json, seal_terminal_receipt, validate_request,
+    verify_terminal_receipt,
 };

--- a/src/contracts/model.rs
+++ b/src/contracts/model.rs
@@ -1,0 +1,111 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const AGENT_RUN_REQUEST_SCHEMA: &str = "gaap.agent-run-request/0.1.0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AgentRunRequest {
+    pub schema_version: String,
+    pub request_id: String,
+    pub run_id: String,
+    pub subject: Subject,
+    pub requested_capability: CapabilityIdentity,
+    pub task: TaskSpec,
+    pub policies: Vec<PolicyIdentity>,
+    pub resource_budget: ResourceBudget,
+    pub approval_context: Vec<ApprovalReference>,
+    pub required_verification: VerificationRequirement,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Subject {
+    pub kind: SubjectKind,
+    pub locator: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectKind {
+    Repository,
+    Artifact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CapabilityIdentity {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TaskSpec {
+    pub instructions: String,
+    pub constraints: Vec<String>,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyIdentity {
+    pub name: String,
+    pub version: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceBudget {
+    pub max_cost_micros: u64,
+    pub max_elapsed_ms: u64,
+    pub max_model_tokens: u64,
+    pub max_tool_calls: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalReference {
+    pub approval_id: String,
+    pub actor_id: String,
+    pub scope: String,
+    pub subject_digest: String,
+    pub evidence: EvidenceReference,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceReference {
+    pub evidence_type: EvidenceType,
+    pub digest: String,
+    pub locator: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceType {
+    Approval,
+    CommandOutput,
+    Artifact,
+    ToolExecution,
+    VerificationAttestation,
+    ResourceUsage,
+    Interruption,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationRequirement {
+    pub independence: VerificationIndependence,
+    pub evidence_types: Vec<EvidenceType>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationIndependence {
+    DifferentActor,
+}

--- a/src/contracts/model.rs
+++ b/src/contracts/model.rs
@@ -1,31 +1,43 @@
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
 
-pub const AGENT_RUN_REQUEST_SCHEMA: &str = "gaap.agent-run-request/0.1.0";
+use crate::{Decision, Gate};
 
+pub const AGENT_RUN_REQUEST_SCHEMA: &str = "gaap.agent-run-request/0.1.0";
+pub const TERMINAL_RUN_RECEIPT_SCHEMA: &str = "gaap.terminal-run-receipt/0.1.0";
+
+/// Immutable input that identifies one governed Agent Run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AgentRunRequest {
+    #[schemars(schema_with = "agent_run_request_schema_version")]
     pub schema_version: String,
+    #[schemars(length(min = 1))]
     pub request_id: String,
+    #[schemars(length(min = 1))]
     pub run_id: String,
     pub subject: Subject,
     pub requested_capability: CapabilityIdentity,
     pub task: TaskSpec,
+    #[schemars(length(min = 1))]
     pub policies: Vec<PolicyIdentity>,
     pub resource_budget: ResourceBudget,
     pub approval_context: Vec<ApprovalReference>,
     pub required_verification: VerificationRequirement,
 }
 
+/// Exact repository or artifact that the Agent Run may inspect or change.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Subject {
     pub kind: SubjectKind,
+    #[schemars(length(min = 1))]
     pub locator: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
     pub digest: String,
 }
 
+/// Closed subject categories supported by contract version 0.1.0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SubjectKind {
@@ -33,58 +45,83 @@ pub enum SubjectKind {
     Artifact,
 }
 
+/// Requested engineering capability bound to its versioned content digest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CapabilityIdentity {
+    #[schemars(length(min = 1))]
     pub name: String,
+    #[schemars(length(min = 1))]
     pub version: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
     pub digest: String,
 }
 
+/// Self-contained task instructions and ordered textual constraints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct TaskSpec {
+    #[schemars(length(min = 1))]
     pub instructions: String,
+    #[schemars(inner(length(min = 1)))]
     pub constraints: Vec<String>,
 }
 
+/// Exact policy identity accepted by a caller's [`super::ContractSupport`].
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
 #[serde(deny_unknown_fields)]
 pub struct PolicyIdentity {
+    #[schemars(length(min = 1))]
     pub name: String,
+    #[schemars(length(min = 1))]
     pub version: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
     pub digest: String,
 }
 
+/// Upper bounds declared for one Agent Run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ResourceBudget {
+    #[schemars(range(max = 9007199254740991_u64))]
     pub max_cost_micros: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
     pub max_elapsed_ms: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
     pub max_model_tokens: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
     pub max_tool_calls: u64,
 }
 
+/// Existing approval evidence bound to an actor, scope, and exact subject.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ApprovalReference {
+    #[schemars(length(min = 1))]
     pub approval_id: String,
+    #[schemars(length(min = 1))]
     pub actor_id: String,
+    #[schemars(length(min = 1))]
     pub scope: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
     pub subject_digest: String,
     pub evidence: EvidenceReference,
 }
 
+/// Content-addressed evidence metadata; raw evidence remains external.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct EvidenceReference {
     pub evidence_type: EvidenceType,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
     pub digest: String,
+    #[schemars(inner(length(min = 1)))]
     pub locator: Option<String>,
 }
 
+/// Closed evidence categories supported by contract version 0.1.0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceType {
@@ -97,15 +134,220 @@ pub enum EvidenceType {
     Interruption,
 }
 
+/// Independent evidence required before an Agent Run may complete.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct VerificationRequirement {
     pub independence: VerificationIndependence,
+    #[schemars(length(min = 1))]
     pub evidence_types: Vec<EvidenceType>,
 }
 
+/// Actor-separation rules supported by contract version 0.1.0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum VerificationIndependence {
     DifferentActor,
+}
+
+/// Lifecycle states for one Agent Run, including four distinct terminal states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunStatus {
+    Accepted,
+    Planning,
+    AwaitingAuthority,
+    Executing,
+    Verifying,
+    Completed,
+    Blocked,
+    Failed,
+    Interrupted,
+}
+
+impl AgentRunStatus {
+    /// Return whether no later lifecycle transition is permitted.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Blocked | Self::Failed | Self::Interrupted
+        )
+    }
+}
+
+/// Cumulative resource usage observed during one Agent Run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceUsage {
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub cost_micros: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub elapsed_ms: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub model_tokens: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub tool_calls: u64,
+}
+
+/// Independent verification result recorded in the receipt ledger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum VerificationVerdict {
+    Pass,
+    Fail,
+}
+
+/// One entry in the immutable, sequence-ordered Terminal Run Receipt ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "event_type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RunEvent {
+    StatusTransition {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        from: AgentRunStatus,
+        to: AgentRunStatus,
+        reason: Option<String>,
+    },
+    PlanRecorded {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        plan_digest: String,
+    },
+    ApprovalRecorded {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        approval: ApprovalReference,
+    },
+    ProtectedEffectDecision {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        #[schemars(length(min = 1))]
+        decision_id: String,
+        gate: Gate,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        protected_effect_digest: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        subject_digest: String,
+        decision: Decision,
+    },
+    ToolExecution {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        #[schemars(length(min = 1))]
+        decision_id: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        protected_effect_digest: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        action_digest: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        capability_digest: String,
+        #[schemars(length(min = 1))]
+        evidence: Vec<EvidenceReference>,
+    },
+    Mutation {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        #[schemars(length(min = 1))]
+        decision_id: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        protected_effect_digest: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        before_subject_digest: String,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        after_subject_digest: String,
+        #[schemars(length(min = 1))]
+        evidence: Vec<EvidenceReference>,
+    },
+    Verification {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+        subject_digest: String,
+        #[schemars(length(min = 1))]
+        implementer_id: String,
+        #[schemars(length(min = 1))]
+        verifier_id: String,
+        verdict: VerificationVerdict,
+        #[schemars(length(min = 1))]
+        evidence: Vec<EvidenceReference>,
+    },
+    Usage {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        usage: ResourceUsage,
+    },
+    Interruption {
+        #[schemars(range(min = 1, max = 9007199254740991_u64))]
+        sequence: u64,
+        #[schemars(inner(length(min = 1)))]
+        actor_id: Option<String>,
+        #[schemars(length(min = 1))]
+        reason: String,
+        evidence: EvidenceReference,
+    },
+}
+
+impl RunEvent {
+    /// Return the one-based position declared by this event.
+    pub fn sequence(&self) -> u64 {
+        match self {
+            Self::StatusTransition { sequence, .. }
+            | Self::PlanRecorded { sequence, .. }
+            | Self::ApprovalRecorded { sequence, .. }
+            | Self::ProtectedEffectDecision { sequence, .. }
+            | Self::ToolExecution { sequence, .. }
+            | Self::Mutation { sequence, .. }
+            | Self::Verification { sequence, .. }
+            | Self::Usage { sequence, .. }
+            | Self::Interruption { sequence, .. } => *sequence,
+        }
+    }
+}
+
+/// Canonical digest preimage containing the terminal Agent Run evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TerminalRunReceiptBody {
+    #[schemars(schema_with = "terminal_run_receipt_schema_version")]
+    pub schema_version: String,
+    #[schemars(length(min = 1))]
+    pub request_id: String,
+    #[schemars(length(min = 1))]
+    pub run_id: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub request_digest: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub initial_subject_digest: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub resulting_subject_digest: String,
+    pub terminal_status: AgentRunStatus,
+    #[schemars(length(min = 1))]
+    pub terminal_reason: String,
+    pub usage: ResourceUsage,
+    #[schemars(length(min = 1))]
+    pub events: Vec<RunEvent>,
+}
+
+/// Content-addressed envelope around a canonical Terminal Run Receipt body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TerminalRunReceipt {
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub receipt_digest: String,
+    pub body: TerminalRunReceiptBody,
+}
+
+fn agent_run_request_schema_version(_: &mut SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "type": "string",
+        "const": AGENT_RUN_REQUEST_SCHEMA
+    })
+}
+
+fn terminal_run_receipt_schema_version(_: &mut SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "type": "string",
+        "const": TERMINAL_RUN_RECEIPT_SCHEMA
+    })
 }

--- a/src/contracts/schema.rs
+++ b/src/contracts/schema.rs
@@ -1,0 +1,31 @@
+use schemars::{Schema, schema_for};
+use serde_json::Value;
+
+use super::model::{AgentRunRequest, TerminalRunReceipt};
+
+const REQUEST_SCHEMA_ID: &str = "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/agent-run/v0.1.0/agent-run-request.schema.json";
+const RECEIPT_SCHEMA_ID: &str = "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json";
+
+/// Generate the Draft 2020-12 Agent Run Request schema from the Rust types.
+pub fn agent_run_request_schema() -> Value {
+    document(
+        schema_for!(AgentRunRequest),
+        REQUEST_SCHEMA_ID,
+        "GAAP Agent Run Request 0.1.0",
+    )
+}
+
+/// Generate the Draft 2020-12 Terminal Run Receipt schema from the Rust types.
+pub fn terminal_run_receipt_schema() -> Value {
+    document(
+        schema_for!(TerminalRunReceipt),
+        RECEIPT_SCHEMA_ID,
+        "GAAP Terminal Run Receipt 0.1.0",
+    )
+}
+
+fn document(mut schema: Schema, id: &str, title: &str) -> Value {
+    schema.insert("$id".to_owned(), id.into());
+    schema.insert("title".to_owned(), title.into());
+    serde_json::to_value(schema).expect("schemars schemas must serialize")
+}

--- a/src/contracts/validation.rs
+++ b/src/contracts/validation.rs
@@ -355,8 +355,6 @@ fn validate_receipt_body(
     let mut latest_usage: Option<ResourceUsage> = None;
     let mut completion_decision: Option<RecordedDecision> = None;
     let mut decisions = BTreeMap::<String, RecordedDecision>::new();
-    let mut plan_digests = BTreeSet::<String>::new();
-    let mut plan_approval_seen = false;
     let mut interruption_seen = false;
 
     for (index, event) in body.events.iter().enumerate() {
@@ -395,16 +393,9 @@ fn validate_receipt_body(
             }
             RunEvent::PlanRecorded { plan_digest, .. } => {
                 validate_digest(plan_digest, &format!("{path}.plan_digest"))?;
-                plan_digests.insert(plan_digest.clone());
             }
             RunEvent::ApprovalRecorded { approval, .. } => {
                 validate_approval(approval, &path)?;
-                if approval.scope == "plan"
-                    && plan_digests.contains(&approval.subject_digest)
-                    && request.approval_context.contains(approval)
-                {
-                    plan_approval_seen = true;
-                }
             }
             RunEvent::ProtectedEffectDecision {
                 sequence,
@@ -472,10 +463,18 @@ fn validate_receipt_body(
                     decision_id,
                     protected_effect_digest,
                     event.sequence(),
+                    &current_subject,
                     &path,
                 )?;
                 validate_digest(action_digest, &format!("{path}.action_digest"))?;
                 validate_digest(capability_digest, &format!("{path}.capability_digest"))?;
+                if capability_digest != &request.requested_capability.digest {
+                    return Err(ContractError::new(
+                        ContractErrorCode::RequestMismatch,
+                        format!("{path}.capability_digest"),
+                        "tool execution capability does not match the Agent Run Request",
+                    ));
+                }
                 validate_evidence_set(evidence, &path)?;
                 if !evidence
                     .iter()
@@ -501,6 +500,7 @@ fn validate_receipt_body(
                     decision_id,
                     protected_effect_digest,
                     *sequence,
+                    &current_subject,
                     &path,
                 )?;
                 validate_digest(
@@ -650,7 +650,6 @@ fn validate_receipt_body(
             last_mutation_sequence,
             latest_passing_verification,
             completion_decision,
-            plan_approval_seen,
         )?;
     } else if completion_decision.is_some() {
         return Err(ContractError::new(
@@ -670,15 +669,7 @@ fn validate_completed_receipt(
     last_mutation_sequence: u64,
     latest_passing_verification: Option<(u64, String)>,
     completion_decision: Option<RecordedDecision>,
-    plan_approval_seen: bool,
 ) -> Result<(), ContractError> {
-    if !plan_approval_seen {
-        return Err(ContractError::new(
-            ContractErrorCode::InvalidContract,
-            "events",
-            "completion requires plan approval evidence from the request context",
-        ));
-    }
     if !usage_within_budget(usage, &request.resource_budget) {
         return Err(ContractError::new(
             ContractErrorCode::InvalidContract,
@@ -728,6 +719,7 @@ fn validate_authorization(
     decision_id: &str,
     protected_effect_digest: &str,
     effect_sequence: u64,
+    current_subject: &str,
     path: &str,
 ) -> Result<(), ContractError> {
     validate_non_empty(decision_id, &format!("{path}.decision_id"))?;
@@ -744,6 +736,7 @@ fn validate_authorization(
     };
     if decision.sequence >= effect_sequence
         || decision.protected_effect_digest != protected_effect_digest
+        || decision.subject_digest != current_subject
         || decision.outcome != Outcome::Allow
     {
         return Err(ContractError::new(
@@ -817,7 +810,10 @@ fn valid_transition(from: AgentRunStatus, to: AgentRunStatus) -> bool {
     if from.is_terminal() || from == to {
         return false;
     }
-    if to.is_terminal() {
+    if matches!(
+        to,
+        AgentRunStatus::Blocked | AgentRunStatus::Failed | AgentRunStatus::Interrupted
+    ) {
         return true;
     }
     matches!(
@@ -835,7 +831,10 @@ fn valid_transition(from: AgentRunStatus, to: AgentRunStatus) -> bool {
                 AgentRunStatus::Executing,
                 AgentRunStatus::AwaitingAuthority | AgentRunStatus::Verifying
             )
-            | (AgentRunStatus::Verifying, AgentRunStatus::Executing)
+            | (
+                AgentRunStatus::Verifying,
+                AgentRunStatus::Executing | AgentRunStatus::Completed
+            )
     )
 }
 

--- a/src/contracts/validation.rs
+++ b/src/contracts/validation.rs
@@ -1,16 +1,20 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-use super::canonical::{canonical_request_bytes, sha256_digest};
+use super::canonical::{canonical_receipt_body_bytes, canonical_request_bytes, sha256_digest};
 use super::model::{
-    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, EvidenceReference, EvidenceType, PolicyIdentity,
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, AgentRunStatus, ApprovalReference,
+    EvidenceReference, EvidenceType, PolicyIdentity, ResourceBudget, ResourceUsage, RunEvent,
+    TERMINAL_RUN_RECEIPT_SCHEMA, TerminalRunReceipt, TerminalRunReceiptBody, VerificationVerdict,
 };
+use crate::{Gate, Outcome};
 
 const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
+/// Stable machine-readable categories returned by contract validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ContractErrorCode {
@@ -26,6 +30,7 @@ pub enum ContractErrorCode {
     ReceiptTampering,
 }
 
+/// Contract validation failure with a stable code and document path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContractError {
     code: ContractErrorCode,
@@ -46,12 +51,19 @@ impl ContractError {
         }
     }
 
+    /// Return the stable machine-readable error category.
     pub fn code(&self) -> ContractErrorCode {
         self.code
     }
 
+    /// Return the contract path that failed validation.
     pub fn path(&self) -> &str {
         &self.path
+    }
+
+    /// Return the human-readable explanation of the failure.
+    pub fn message(&self) -> &str {
+        &self.message
     }
 }
 
@@ -63,23 +75,27 @@ impl Display for ContractError {
 
 impl Error for ContractError {}
 
+/// Exact policy identities that a caller is prepared to evaluate.
 #[derive(Debug, Clone, Default)]
 pub struct ContractSupport {
     policies: BTreeSet<PolicyIdentity>,
 }
 
 impl ContractSupport {
+    /// Construct support from exact name, version, and digest tuples.
     pub fn new(policies: impl IntoIterator<Item = PolicyIdentity>) -> Self {
         Self {
             policies: policies.into_iter().collect(),
         }
     }
 
+    /// Return whether an exact policy identity is supported.
     pub fn supports(&self, policy: &PolicyIdentity) -> bool {
         self.policies.contains(policy)
     }
 }
 
+/// Strictly parse an Agent Run Request from UTF-8 JSON bytes.
 pub fn parse_agent_run_request_json(bytes: &[u8]) -> Result<AgentRunRequest, ContractError> {
     serde_json::from_slice(bytes).map_err(|error| {
         ContractError::new(
@@ -90,6 +106,18 @@ pub fn parse_agent_run_request_json(bytes: &[u8]) -> Result<AgentRunRequest, Con
     })
 }
 
+/// Strictly parse a Terminal Run Receipt from UTF-8 JSON bytes.
+pub fn parse_terminal_run_receipt_json(bytes: &[u8]) -> Result<TerminalRunReceipt, ContractError> {
+    serde_json::from_slice(bytes).map_err(|error| {
+        ContractError::new(
+            ContractErrorCode::InvalidJson,
+            "$",
+            format!("invalid Terminal Run Receipt JSON: {error}"),
+        )
+    })
+}
+
+/// Validate request semantics and return its canonical SHA-256 digest.
 pub fn validate_request(
     request: &AgentRunRequest,
     support: &ContractSupport,
@@ -218,6 +246,605 @@ pub fn validate_request(
     }
 
     canonical_request_bytes(request).map(|bytes| sha256_digest(&bytes))
+}
+
+/// Validate a terminal body and return its content-addressed receipt envelope.
+pub fn seal_terminal_receipt(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    body: TerminalRunReceiptBody,
+) -> Result<TerminalRunReceipt, ContractError> {
+    validate_receipt_body(request, support, &body)?;
+    let receipt_digest = sha256_digest(&canonical_receipt_body_bytes(&body)?);
+    Ok(TerminalRunReceipt {
+        receipt_digest,
+        body,
+    })
+}
+
+/// Verify a receipt's digest and semantic binding to an Agent Run Request.
+pub fn verify_terminal_receipt(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    receipt: &TerminalRunReceipt,
+) -> Result<(), ContractError> {
+    validate_digest(&receipt.receipt_digest, "receipt_digest").map_err(|_| {
+        ContractError::new(
+            ContractErrorCode::ReceiptTampering,
+            "receipt_digest",
+            "receipt digest is malformed",
+        )
+    })?;
+    let actual_digest = sha256_digest(&canonical_receipt_body_bytes(&receipt.body)?);
+    if actual_digest != receipt.receipt_digest {
+        return Err(ContractError::new(
+            ContractErrorCode::ReceiptTampering,
+            "receipt_digest",
+            format!(
+                "receipt digest mismatch: expected {}, calculated {actual_digest}",
+                receipt.receipt_digest
+            ),
+        ));
+    }
+    validate_receipt_body(request, support, &receipt.body)
+}
+
+#[derive(Debug, Clone)]
+struct RecordedDecision {
+    sequence: u64,
+    gate: Gate,
+    protected_effect_digest: String,
+    subject_digest: String,
+    outcome: Outcome,
+    code: String,
+}
+
+fn validate_receipt_body(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    body: &TerminalRunReceiptBody,
+) -> Result<(), ContractError> {
+    let expected_request_digest = validate_request(request, support)?;
+    if body.schema_version != TERMINAL_RUN_RECEIPT_SCHEMA {
+        return Err(ContractError::new(
+            ContractErrorCode::UnsupportedSchema,
+            "body.schema_version",
+            format!(
+                "unsupported Terminal Run Receipt schema: {}",
+                body.schema_version
+            ),
+        ));
+    }
+    if body.request_id != request.request_id {
+        return Err(request_mismatch("body.request_id"));
+    }
+    if body.run_id != request.run_id {
+        return Err(request_mismatch("body.run_id"));
+    }
+    if body.request_digest != expected_request_digest {
+        return Err(request_mismatch("body.request_digest"));
+    }
+    if body.initial_subject_digest != request.subject.digest {
+        return Err(request_mismatch("body.initial_subject_digest"));
+    }
+    validate_digest(
+        &body.resulting_subject_digest,
+        "body.resulting_subject_digest",
+    )?;
+    if !body.terminal_status.is_terminal() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "body.terminal_status",
+            "receipt status must be terminal",
+        ));
+    }
+    validate_non_empty(&body.terminal_reason, "body.terminal_reason")?;
+    validate_usage(&body.usage, "body.usage")?;
+    if body.events.is_empty() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "events",
+            "terminal receipt must contain at least one event",
+        ));
+    }
+
+    let mut status = AgentRunStatus::Accepted;
+    let mut current_subject = body.initial_subject_digest.clone();
+    let mut last_mutation_sequence = 0;
+    let mut latest_passing_verification: Option<(u64, String)> = None;
+    let mut latest_usage: Option<ResourceUsage> = None;
+    let mut completion_decision: Option<RecordedDecision> = None;
+    let mut decisions = BTreeMap::<String, RecordedDecision>::new();
+    let mut plan_digests = BTreeSet::<String>::new();
+    let mut plan_approval_seen = false;
+    let mut interruption_seen = false;
+
+    for (index, event) in body.events.iter().enumerate() {
+        let path = format!("events[{index}]");
+        let expected_sequence = u64::try_from(index + 1).map_err(|_| {
+            ContractError::new(
+                ContractErrorCode::InvalidContract,
+                &path,
+                "event sequence exceeds the supported integer range",
+            )
+        })?;
+        if event.sequence() != expected_sequence {
+            return Err(ContractError::new(
+                ContractErrorCode::InvalidContract,
+                format!("{path}.sequence"),
+                format!("event sequence must be contiguous from 1; expected {expected_sequence}"),
+            ));
+        }
+        validate_safe_integer(event.sequence(), &format!("{path}.sequence"))?;
+
+        match event {
+            RunEvent::StatusTransition {
+                from, to, reason, ..
+            } => {
+                if *from != status || !valid_transition(*from, *to) {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidTransition,
+                        path,
+                        format!("invalid Agent Run transition from {from:?} to {to:?}"),
+                    ));
+                }
+                if let Some(reason) = reason {
+                    validate_non_empty(reason, &format!("{path}.reason"))?;
+                }
+                status = *to;
+            }
+            RunEvent::PlanRecorded { plan_digest, .. } => {
+                validate_digest(plan_digest, &format!("{path}.plan_digest"))?;
+                plan_digests.insert(plan_digest.clone());
+            }
+            RunEvent::ApprovalRecorded { approval, .. } => {
+                validate_approval(approval, &path)?;
+                if approval.scope == "plan"
+                    && plan_digests.contains(&approval.subject_digest)
+                    && request.approval_context.contains(approval)
+                {
+                    plan_approval_seen = true;
+                }
+            }
+            RunEvent::ProtectedEffectDecision {
+                sequence,
+                decision_id,
+                gate,
+                protected_effect_digest,
+                subject_digest,
+                decision,
+            } => {
+                validate_non_empty(decision_id, &format!("{path}.decision_id"))?;
+                validate_digest(
+                    protected_effect_digest,
+                    &format!("{path}.protected_effect_digest"),
+                )?;
+                validate_digest(subject_digest, &format!("{path}.subject_digest"))?;
+                if subject_digest != &current_subject {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.subject_digest"),
+                        "decision is not bound to the current subject",
+                    ));
+                }
+                validate_non_empty(&decision.code, &format!("{path}.decision.code"))?;
+                for (effect_index, effect) in decision.effects.iter().enumerate() {
+                    validate_non_empty(
+                        effect,
+                        &format!("{path}.decision.effects[{effect_index}]"),
+                    )?;
+                }
+                let record = RecordedDecision {
+                    sequence: *sequence,
+                    gate: *gate,
+                    protected_effect_digest: protected_effect_digest.clone(),
+                    subject_digest: subject_digest.clone(),
+                    outcome: decision.outcome.clone(),
+                    code: decision.code.clone(),
+                };
+                if decisions
+                    .insert(decision_id.clone(), record.clone())
+                    .is_some()
+                {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.decision_id"),
+                        "decision IDs must be unique",
+                    ));
+                }
+                if *gate == Gate::Workflow
+                    && decision.outcome == Outcome::Allow
+                    && decision.code == "workflow.completion_authorized"
+                {
+                    completion_decision = Some(record);
+                }
+            }
+            RunEvent::ToolExecution {
+                decision_id,
+                protected_effect_digest,
+                action_digest,
+                capability_digest,
+                evidence,
+                ..
+            } => {
+                validate_authorization(
+                    &decisions,
+                    decision_id,
+                    protected_effect_digest,
+                    event.sequence(),
+                    &path,
+                )?;
+                validate_digest(action_digest, &format!("{path}.action_digest"))?;
+                validate_digest(capability_digest, &format!("{path}.capability_digest"))?;
+                validate_evidence_set(evidence, &path)?;
+                if !evidence
+                    .iter()
+                    .any(|item| item.evidence_type == EvidenceType::ToolExecution)
+                {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.evidence"),
+                        "tool execution requires tool_execution evidence",
+                    ));
+                }
+            }
+            RunEvent::Mutation {
+                sequence,
+                decision_id,
+                protected_effect_digest,
+                before_subject_digest,
+                after_subject_digest,
+                evidence,
+            } => {
+                validate_authorization(
+                    &decisions,
+                    decision_id,
+                    protected_effect_digest,
+                    *sequence,
+                    &path,
+                )?;
+                validate_digest(
+                    before_subject_digest,
+                    &format!("{path}.before_subject_digest"),
+                )?;
+                validate_digest(
+                    after_subject_digest,
+                    &format!("{path}.after_subject_digest"),
+                )?;
+                if before_subject_digest != &current_subject {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.before_subject_digest"),
+                        "mutation does not begin at the current subject",
+                    ));
+                }
+                validate_evidence_set(evidence, &path)?;
+                if !evidence
+                    .iter()
+                    .any(|item| item.evidence_type == EvidenceType::Artifact)
+                {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.evidence"),
+                        "mutation requires artifact evidence",
+                    ));
+                }
+                current_subject.clone_from(after_subject_digest);
+                last_mutation_sequence = *sequence;
+            }
+            RunEvent::Verification {
+                sequence,
+                subject_digest,
+                implementer_id,
+                verifier_id,
+                verdict,
+                evidence,
+            } => {
+                validate_digest(subject_digest, &format!("{path}.subject_digest"))?;
+                validate_non_empty(implementer_id, &format!("{path}.implementer_id"))?;
+                validate_non_empty(verifier_id, &format!("{path}.verifier_id"))?;
+                validate_evidence_set(evidence, &path)?;
+                if *verdict == VerificationVerdict::Pass {
+                    if implementer_id == verifier_id {
+                        return Err(ContractError::new(
+                            ContractErrorCode::InvalidContract,
+                            format!("{path}.verifier_id"),
+                            "passing verification must use a different actor",
+                        ));
+                    }
+                    for required in &request.required_verification.evidence_types {
+                        if !evidence.iter().any(|item| item.evidence_type == *required) {
+                            return Err(ContractError::new(
+                                ContractErrorCode::InvalidContract,
+                                format!("{path}.evidence"),
+                                format!("missing required {required:?} evidence"),
+                            ));
+                        }
+                    }
+                    if subject_digest == &current_subject {
+                        latest_passing_verification = Some((*sequence, subject_digest.clone()));
+                    }
+                }
+            }
+            RunEvent::Usage { usage, .. } => {
+                validate_usage(usage, &format!("{path}.usage"))?;
+                if latest_usage
+                    .as_ref()
+                    .is_some_and(|previous| !usage_is_monotonic(previous, usage))
+                {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.usage"),
+                        "cumulative usage must not decrease",
+                    ));
+                }
+                latest_usage = Some(usage.clone());
+            }
+            RunEvent::Interruption {
+                actor_id,
+                reason,
+                evidence,
+                ..
+            } => {
+                if let Some(actor_id) = actor_id {
+                    validate_non_empty(actor_id, &format!("{path}.actor_id"))?;
+                }
+                validate_non_empty(reason, &format!("{path}.reason"))?;
+                validate_evidence(evidence, &format!("{path}.evidence"))?;
+                if evidence.evidence_type != EvidenceType::Interruption {
+                    return Err(ContractError::new(
+                        ContractErrorCode::InvalidContract,
+                        format!("{path}.evidence.evidence_type"),
+                        "interruption event requires interruption evidence",
+                    ));
+                }
+                interruption_seen = true;
+            }
+        }
+    }
+
+    if status != body.terminal_status {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidTransition,
+            "body.terminal_status",
+            "terminal status does not match the final lifecycle transition",
+        ));
+    }
+    if !matches!(
+        body.events.last(),
+        Some(RunEvent::StatusTransition { to, .. }) if *to == body.terminal_status
+    ) {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidTransition,
+            "events",
+            "the final event must transition to the declared terminal status",
+        ));
+    }
+    if current_subject != body.resulting_subject_digest {
+        return Err(ContractError::new(
+            ContractErrorCode::RequestMismatch,
+            "body.resulting_subject_digest",
+            "resulting subject does not match the latest observed mutation",
+        ));
+    }
+    if latest_usage.as_ref() != Some(&body.usage) {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "body.usage",
+            "receipt usage must equal the final cumulative usage event",
+        ));
+    }
+    if body.terminal_status == AgentRunStatus::Interrupted && !interruption_seen {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "events",
+            "interrupted receipt requires interruption evidence",
+        ));
+    }
+
+    if body.terminal_status == AgentRunStatus::Completed {
+        validate_completed_receipt(
+            request,
+            &body.usage,
+            &current_subject,
+            last_mutation_sequence,
+            latest_passing_verification,
+            completion_decision,
+            plan_approval_seen,
+        )?;
+    } else if completion_decision.is_some() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "body.terminal_status",
+            "a completion-authorized receipt must terminate as completed",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_completed_receipt(
+    request: &AgentRunRequest,
+    usage: &ResourceUsage,
+    current_subject: &str,
+    last_mutation_sequence: u64,
+    latest_passing_verification: Option<(u64, String)>,
+    completion_decision: Option<RecordedDecision>,
+    plan_approval_seen: bool,
+) -> Result<(), ContractError> {
+    if !plan_approval_seen {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "events",
+            "completion requires plan approval evidence from the request context",
+        ));
+    }
+    if !usage_within_budget(usage, &request.resource_budget) {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "body.usage",
+            "completed run exceeds its resource budget",
+        ));
+    }
+    let Some((verification_sequence, verification_subject)) = latest_passing_verification else {
+        return Err(ContractError::new(
+            ContractErrorCode::StaleVerification,
+            "events",
+            "completion requires a current passing independent verification",
+        ));
+    };
+    if verification_sequence <= last_mutation_sequence || verification_subject != current_subject {
+        return Err(ContractError::new(
+            ContractErrorCode::StaleVerification,
+            "events",
+            "a mutation after verification makes that verification insufficient",
+        ));
+    }
+    let Some(completion) = completion_decision else {
+        return Err(ContractError::new(
+            ContractErrorCode::UnauthorizedEffect,
+            "events",
+            "completion requires a workflow completion allow decision",
+        ));
+    };
+    if completion.sequence <= verification_sequence
+        || completion.subject_digest != current_subject
+        || completion.protected_effect_digest != current_subject
+        || completion.outcome != Outcome::Allow
+        || completion.gate != Gate::Workflow
+        || completion.code != "workflow.completion_authorized"
+    {
+        return Err(ContractError::new(
+            ContractErrorCode::UnauthorizedEffect,
+            "events",
+            "completion decision is not bound to the current verified subject",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_authorization(
+    decisions: &BTreeMap<String, RecordedDecision>,
+    decision_id: &str,
+    protected_effect_digest: &str,
+    effect_sequence: u64,
+    path: &str,
+) -> Result<(), ContractError> {
+    validate_non_empty(decision_id, &format!("{path}.decision_id"))?;
+    validate_digest(
+        protected_effect_digest,
+        &format!("{path}.protected_effect_digest"),
+    )?;
+    let Some(decision) = decisions.get(decision_id) else {
+        return Err(ContractError::new(
+            ContractErrorCode::UnauthorizedEffect,
+            format!("{path}.decision_id"),
+            "effect does not reference an earlier decision",
+        ));
+    };
+    if decision.sequence >= effect_sequence
+        || decision.protected_effect_digest != protected_effect_digest
+        || decision.outcome != Outcome::Allow
+    {
+        return Err(ContractError::new(
+            ContractErrorCode::UnauthorizedEffect,
+            format!("{path}.decision_id"),
+            "effect requires an earlier matching allow decision",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_approval(approval: &ApprovalReference, path: &str) -> Result<(), ContractError> {
+    validate_non_empty(
+        &approval.approval_id,
+        &format!("{path}.approval.approval_id"),
+    )?;
+    validate_non_empty(&approval.actor_id, &format!("{path}.approval.actor_id"))?;
+    validate_non_empty(&approval.scope, &format!("{path}.approval.scope"))?;
+    validate_digest(
+        &approval.subject_digest,
+        &format!("{path}.approval.subject_digest"),
+    )?;
+    validate_evidence(&approval.evidence, &format!("{path}.approval.evidence"))?;
+    if approval.evidence.evidence_type != EvidenceType::Approval {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            format!("{path}.approval.evidence.evidence_type"),
+            "approval event requires approval evidence",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_evidence_set(evidence: &[EvidenceReference], path: &str) -> Result<(), ContractError> {
+    if evidence.is_empty() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            format!("{path}.evidence"),
+            "event requires content-addressed evidence",
+        ));
+    }
+    for (index, item) in evidence.iter().enumerate() {
+        validate_evidence(item, &format!("{path}.evidence[{index}]"))?;
+    }
+    Ok(())
+}
+
+fn validate_usage(usage: &ResourceUsage, path: &str) -> Result<(), ContractError> {
+    validate_safe_integer(usage.cost_micros, &format!("{path}.cost_micros"))?;
+    validate_safe_integer(usage.elapsed_ms, &format!("{path}.elapsed_ms"))?;
+    validate_safe_integer(usage.model_tokens, &format!("{path}.model_tokens"))?;
+    validate_safe_integer(usage.tool_calls, &format!("{path}.tool_calls"))?;
+    Ok(())
+}
+
+fn usage_is_monotonic(previous: &ResourceUsage, current: &ResourceUsage) -> bool {
+    current.cost_micros >= previous.cost_micros
+        && current.elapsed_ms >= previous.elapsed_ms
+        && current.model_tokens >= previous.model_tokens
+        && current.tool_calls >= previous.tool_calls
+}
+
+fn usage_within_budget(usage: &ResourceUsage, budget: &ResourceBudget) -> bool {
+    usage.cost_micros <= budget.max_cost_micros
+        && usage.elapsed_ms <= budget.max_elapsed_ms
+        && usage.model_tokens <= budget.max_model_tokens
+        && usage.tool_calls <= budget.max_tool_calls
+}
+
+fn valid_transition(from: AgentRunStatus, to: AgentRunStatus) -> bool {
+    if from.is_terminal() || from == to {
+        return false;
+    }
+    if to.is_terminal() {
+        return true;
+    }
+    matches!(
+        (from, to),
+        (AgentRunStatus::Accepted, AgentRunStatus::Planning)
+            | (
+                AgentRunStatus::Planning,
+                AgentRunStatus::AwaitingAuthority | AgentRunStatus::Executing
+            )
+            | (
+                AgentRunStatus::AwaitingAuthority,
+                AgentRunStatus::Planning | AgentRunStatus::Executing
+            )
+            | (
+                AgentRunStatus::Executing,
+                AgentRunStatus::AwaitingAuthority | AgentRunStatus::Verifying
+            )
+            | (AgentRunStatus::Verifying, AgentRunStatus::Executing)
+    )
+}
+
+fn request_mismatch(path: &str) -> ContractError {
+    ContractError::new(
+        ContractErrorCode::RequestMismatch,
+        path,
+        "receipt does not match the validated Agent Run Request",
+    )
 }
 
 pub(crate) fn validate_non_empty(value: &str, path: &str) -> Result<(), ContractError> {

--- a/src/contracts/validation.rs
+++ b/src/contracts/validation.rs
@@ -208,6 +208,13 @@ pub fn validate_request(
         validate_non_empty(&approval.actor_id, &format!("{path}.actor_id"))?;
         validate_non_empty(&approval.scope, &format!("{path}.scope"))?;
         validate_digest(&approval.subject_digest, &format!("{path}.subject_digest"))?;
+        if approval.subject_digest != request.subject.digest {
+            return Err(ContractError::new(
+                ContractErrorCode::RequestMismatch,
+                format!("{path}.subject_digest"),
+                "request approval does not match the requested subject",
+            ));
+        }
         if approval.evidence.evidence_type != EvidenceType::Approval {
             return Err(ContractError::new(
                 ContractErrorCode::InvalidContract,
@@ -464,6 +471,7 @@ fn validate_receipt_body(
                     protected_effect_digest,
                     event.sequence(),
                     &current_subject,
+                    Gate::Permission,
                     &path,
                 )?;
                 validate_digest(action_digest, &format!("{path}.action_digest"))?;
@@ -501,6 +509,7 @@ fn validate_receipt_body(
                     protected_effect_digest,
                     *sequence,
                     &current_subject,
+                    Gate::Workflow,
                     &path,
                 )?;
                 validate_digest(
@@ -720,6 +729,7 @@ fn validate_authorization(
     protected_effect_digest: &str,
     effect_sequence: u64,
     current_subject: &str,
+    expected_gate: Gate,
     path: &str,
 ) -> Result<(), ContractError> {
     validate_non_empty(decision_id, &format!("{path}.decision_id"))?;
@@ -737,6 +747,7 @@ fn validate_authorization(
     if decision.sequence >= effect_sequence
         || decision.protected_effect_digest != protected_effect_digest
         || decision.subject_digest != current_subject
+        || decision.gate != expected_gate
         || decision.outcome != Outcome::Allow
     {
         return Err(ContractError::new(

--- a/src/contracts/validation.rs
+++ b/src/contracts/validation.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use super::canonical::{canonical_request_bytes, sha256_digest};
+use super::model::{
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, EvidenceReference, EvidenceType, PolicyIdentity,
+};
+
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractErrorCode {
+    InvalidJson,
+    UnsupportedSchema,
+    UnknownPolicy,
+    InvalidDigest,
+    InvalidContract,
+    InvalidTransition,
+    UnauthorizedEffect,
+    StaleVerification,
+    RequestMismatch,
+    ReceiptTampering,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractError {
+    code: ContractErrorCode,
+    path: String,
+    message: String,
+}
+
+impl ContractError {
+    pub(crate) fn new(
+        code: ContractErrorCode,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> ContractErrorCode {
+        self.code
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl Display for ContractError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.path, self.message)
+    }
+}
+
+impl Error for ContractError {}
+
+#[derive(Debug, Clone, Default)]
+pub struct ContractSupport {
+    policies: BTreeSet<PolicyIdentity>,
+}
+
+impl ContractSupport {
+    pub fn new(policies: impl IntoIterator<Item = PolicyIdentity>) -> Self {
+        Self {
+            policies: policies.into_iter().collect(),
+        }
+    }
+
+    pub fn supports(&self, policy: &PolicyIdentity) -> bool {
+        self.policies.contains(policy)
+    }
+}
+
+pub fn parse_agent_run_request_json(bytes: &[u8]) -> Result<AgentRunRequest, ContractError> {
+    serde_json::from_slice(bytes).map_err(|error| {
+        ContractError::new(
+            ContractErrorCode::InvalidJson,
+            "$",
+            format!("invalid Agent Run Request JSON: {error}"),
+        )
+    })
+}
+
+pub fn validate_request(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+) -> Result<String, ContractError> {
+    if request.schema_version != AGENT_RUN_REQUEST_SCHEMA {
+        return Err(ContractError::new(
+            ContractErrorCode::UnsupportedSchema,
+            "schema_version",
+            format!(
+                "unsupported Agent Run Request schema: {}",
+                request.schema_version
+            ),
+        ));
+    }
+    validate_non_empty(&request.request_id, "request_id")?;
+    validate_non_empty(&request.run_id, "run_id")?;
+    validate_non_empty(&request.subject.locator, "subject.locator")?;
+    validate_digest(&request.subject.digest, "subject.digest")?;
+    validate_non_empty(
+        &request.requested_capability.name,
+        "requested_capability.name",
+    )?;
+    validate_non_empty(
+        &request.requested_capability.version,
+        "requested_capability.version",
+    )?;
+    validate_digest(
+        &request.requested_capability.digest,
+        "requested_capability.digest",
+    )?;
+    validate_non_empty(&request.task.instructions, "task.instructions")?;
+    for (index, constraint) in request.task.constraints.iter().enumerate() {
+        validate_non_empty(constraint, &format!("task.constraints[{index}]"))?;
+    }
+
+    if request.policies.is_empty() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "policies",
+            "at least one policy identity is required",
+        ));
+    }
+    let mut identities = BTreeSet::new();
+    for (index, policy) in request.policies.iter().enumerate() {
+        let path = format!("policies[{index}]");
+        validate_non_empty(&policy.name, &format!("{path}.name"))?;
+        validate_non_empty(&policy.version, &format!("{path}.version"))?;
+        validate_digest(&policy.digest, &format!("{path}.digest"))?;
+        if !identities.insert(policy) {
+            return Err(ContractError::new(
+                ContractErrorCode::InvalidContract,
+                path,
+                "duplicate policy identity",
+            ));
+        }
+        if !support.supports(policy) {
+            return Err(ContractError::new(
+                ContractErrorCode::UnknownPolicy,
+                path,
+                format!(
+                    "unsupported policy identity: {}@{} ({})",
+                    policy.name, policy.version, policy.digest
+                ),
+            ));
+        }
+    }
+
+    validate_safe_integer(
+        request.resource_budget.max_cost_micros,
+        "resource_budget.max_cost_micros",
+    )?;
+    validate_safe_integer(
+        request.resource_budget.max_elapsed_ms,
+        "resource_budget.max_elapsed_ms",
+    )?;
+    validate_safe_integer(
+        request.resource_budget.max_model_tokens,
+        "resource_budget.max_model_tokens",
+    )?;
+    validate_safe_integer(
+        request.resource_budget.max_tool_calls,
+        "resource_budget.max_tool_calls",
+    )?;
+
+    for (index, approval) in request.approval_context.iter().enumerate() {
+        let path = format!("approval_context[{index}]");
+        validate_non_empty(&approval.approval_id, &format!("{path}.approval_id"))?;
+        validate_non_empty(&approval.actor_id, &format!("{path}.actor_id"))?;
+        validate_non_empty(&approval.scope, &format!("{path}.scope"))?;
+        validate_digest(&approval.subject_digest, &format!("{path}.subject_digest"))?;
+        if approval.evidence.evidence_type != EvidenceType::Approval {
+            return Err(ContractError::new(
+                ContractErrorCode::InvalidContract,
+                format!("{path}.evidence.evidence_type"),
+                "approval context must reference approval evidence",
+            ));
+        }
+        validate_evidence(&approval.evidence, &format!("{path}.evidence"))?;
+    }
+
+    if request.required_verification.evidence_types.is_empty() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            "required_verification.evidence_types",
+            "at least one verification evidence type is required",
+        ));
+    }
+    for (index, evidence_type) in request
+        .required_verification
+        .evidence_types
+        .iter()
+        .enumerate()
+    {
+        if !matches!(
+            evidence_type,
+            EvidenceType::CommandOutput
+                | EvidenceType::Artifact
+                | EvidenceType::VerificationAttestation
+        ) {
+            return Err(ContractError::new(
+                ContractErrorCode::InvalidContract,
+                format!("required_verification.evidence_types[{index}]"),
+                "evidence type cannot satisfy independent verification",
+            ));
+        }
+    }
+
+    canonical_request_bytes(request).map(|bytes| sha256_digest(&bytes))
+}
+
+pub(crate) fn validate_non_empty(value: &str, path: &str) -> Result<(), ContractError> {
+    if value.trim().is_empty() {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            path,
+            "value must not be empty",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_digest(value: &str, path: &str) -> Result<(), ContractError> {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return Err(invalid_digest(path));
+    };
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(invalid_digest(path));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_safe_integer(value: u64, path: &str) -> Result<(), ContractError> {
+    if value > MAX_SAFE_INTEGER {
+        return Err(ContractError::new(
+            ContractErrorCode::InvalidContract,
+            path,
+            format!("integer exceeds the JCS safe maximum {MAX_SAFE_INTEGER}"),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_evidence(
+    evidence: &EvidenceReference,
+    path: &str,
+) -> Result<(), ContractError> {
+    validate_digest(&evidence.digest, &format!("{path}.digest"))?;
+    if let Some(locator) = &evidence.locator {
+        validate_non_empty(locator, &format!("{path}.locator"))?;
+    }
+    Ok(())
+}
+
+fn invalid_digest(path: &str) -> ContractError {
+    ContractError::new(
+        ContractErrorCode::InvalidDigest,
+        path,
+        "expected sha256 followed by 64 lowercase hexadecimal characters",
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -15,7 +16,8 @@ const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const DANGEROUS_RISK_TAGS: &[&str] = &["destructive_flag", "destructive_path"];
 
 /// A deterministic decision point owned by the run coordinator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum Gate {
     /// Approval for the exact current plan before mutation.
     Plan,
@@ -50,7 +52,7 @@ impl FromStr for Gate {
 }
 
 /// The precedence-bearing result of an integrity decision.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Outcome {
     /// The protected effect may proceed.
@@ -62,7 +64,7 @@ pub enum Outcome {
 }
 
 /// A normalized decision returned at a protected agent-run effect.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Decision {
     pub outcome: Outcome,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub mod contracts;
+
 const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const DANGEROUS_RISK_TAGS: &[&str] = &["destructive_flag", "destructive_path"];
 

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -25,8 +25,8 @@ fn approval() -> ApprovalReference {
     ApprovalReference {
         approval_id: "approval-001".to_owned(),
         actor_id: "maintainer-001".to_owned(),
-        scope: "plan".to_owned(),
-        subject_digest: digest('d'),
+        scope: "subject".to_owned(),
+        subject_digest: digest('a'),
         evidence: EvidenceReference {
             evidence_type: EvidenceType::Approval,
             digest: digest('e'),
@@ -150,26 +150,38 @@ fn completed_body(request_digest: String) -> TerminalRunReceiptBody {
                 capability_digest: digest('c'),
                 evidence: vec![evidence(EvidenceType::ToolExecution, '9')],
             },
-            RunEvent::Mutation {
+            RunEvent::ProtectedEffectDecision {
                 sequence: 7,
-                decision_id: "decision-tool-001".to_owned(),
+                decision_id: "decision-mutation-001".to_owned(),
+                gate: Gate::Workflow,
+                protected_effect_digest: protected_effect.clone(),
+                subject_digest: initial_subject.clone(),
+                decision: Decision {
+                    outcome: Outcome::Allow,
+                    code: "workflow.mutation_authorized".to_owned(),
+                    effects: vec!["record_mutation_authorization".to_owned()],
+                },
+            },
+            RunEvent::Mutation {
+                sequence: 8,
+                decision_id: "decision-mutation-001".to_owned(),
                 protected_effect_digest: protected_effect,
                 before_subject_digest: initial_subject,
                 after_subject_digest: resulting_subject.clone(),
                 evidence: vec![evidence(EvidenceType::Artifact, '0')],
             },
             RunEvent::Usage {
-                sequence: 8,
+                sequence: 9,
                 usage: usage(),
             },
             RunEvent::StatusTransition {
-                sequence: 9,
+                sequence: 10,
                 from: AgentRunStatus::Executing,
                 to: AgentRunStatus::Verifying,
                 reason: None,
             },
             RunEvent::Verification {
-                sequence: 10,
+                sequence: 11,
                 subject_digest: resulting_subject.clone(),
                 implementer_id: "executor-001".to_owned(),
                 verifier_id: "verifier-001".to_owned(),
@@ -180,7 +192,7 @@ fn completed_body(request_digest: String) -> TerminalRunReceiptBody {
                 ],
             },
             RunEvent::ProtectedEffectDecision {
-                sequence: 11,
+                sequence: 12,
                 decision_id: "decision-completion-001".to_owned(),
                 gate: Gate::Workflow,
                 protected_effect_digest: resulting_subject.clone(),
@@ -192,7 +204,7 @@ fn completed_body(request_digest: String) -> TerminalRunReceiptBody {
                 },
             },
             RunEvent::StatusTransition {
-                sequence: 12,
+                sequence: 13,
                 from: AgentRunStatus::Verifying,
                 to: AgentRunStatus::Completed,
                 reason: Some("workflow.completion_authorized".to_owned()),
@@ -274,7 +286,7 @@ fn supported_request_returns_a_stable_canonical_digest() {
     assert_eq!(reparsed, request);
     assert_eq!(
         request_digest,
-        "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632"
+        "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89"
     );
 }
 
@@ -299,6 +311,19 @@ fn request_rejects_an_unknown_schema_version() {
 
     assert_eq!(error.code(), ContractErrorCode::UnsupportedSchema);
     assert_eq!(error.path(), "schema_version");
+}
+
+#[test]
+fn request_rejects_approval_for_a_different_subject() {
+    let mut request = request();
+    request.approval_context[0].subject_digest = digest('d');
+    let support = ContractSupport::new([policy()]);
+
+    let error = validate_request(&request, &support)
+        .expect_err("request approval must bind to the requested subject");
+
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+    assert_eq!(error.path(), "approval_context[0].subject_digest");
 }
 
 #[test]
@@ -407,6 +432,42 @@ fn block_decision_cannot_authorize_a_tool_execution() {
 }
 
 #[test]
+fn unrelated_gate_cannot_authorize_a_tool_execution() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::ProtectedEffectDecision { gate, .. } = &mut body.events[4] else {
+        panic!("fifth event should be the tool decision");
+    };
+    *gate = Gate::Verification;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("verification gate must not authorize tool execution");
+
+    assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+    assert_eq!(error.path(), "events[5].decision_id");
+}
+
+#[test]
+fn permission_gate_cannot_authorize_a_mutation() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::ProtectedEffectDecision { gate, .. } = &mut body.events[6] else {
+        panic!("seventh event should be the mutation decision");
+    };
+    *gate = Gate::Permission;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("permission gate must not authorize mutation");
+
+    assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+    assert_eq!(error.path(), "events[7].decision_id");
+}
+
+#[test]
 fn tool_execution_must_use_the_requested_capability() {
     let request = request();
     let support = ContractSupport::new([policy()]);
@@ -437,9 +498,9 @@ fn mutation_after_verification_makes_completion_stale() {
     let later_subject = digest('6');
     body.resulting_subject_digest = later_subject.clone();
     body.events.insert(
-        10,
+        11,
         RunEvent::ProtectedEffectDecision {
-            sequence: 11,
+            sequence: 12,
             decision_id: "decision-later-mutation-001".to_owned(),
             gate: Gate::Workflow,
             protected_effect_digest: digest('4'),
@@ -452,9 +513,9 @@ fn mutation_after_verification_makes_completion_stale() {
         },
     );
     body.events.insert(
-        11,
+        12,
         RunEvent::Mutation {
-            sequence: 12,
+            sequence: 13,
             decision_id: "decision-later-mutation-001".to_owned(),
             protected_effect_digest: digest('4'),
             before_subject_digest: prior_subject,
@@ -462,14 +523,14 @@ fn mutation_after_verification_makes_completion_stale() {
             evidence: vec![evidence(EvidenceType::Artifact, '5')],
         },
     );
-    for (index, event) in body.events.iter_mut().enumerate().skip(12) {
+    for (index, event) in body.events.iter_mut().enumerate().skip(13) {
         set_event_sequence(event, (index + 1) as u64);
     }
     let RunEvent::ProtectedEffectDecision {
         protected_effect_digest,
         subject_digest,
         ..
-    } = &mut body.events[12]
+    } = &mut body.events[13]
     else {
         panic!("completion decision should follow the later mutation");
     };
@@ -807,9 +868,9 @@ fn completed_receipt_rejects_self_verification() {
         implementer_id,
         verifier_id,
         ..
-    } = &mut body.events[9]
+    } = &mut body.events[10]
     else {
-        panic!("ninth event should be verification");
+        panic!("eleventh event should be verification");
     };
     *verifier_id = implementer_id.clone();
 
@@ -817,7 +878,7 @@ fn completed_receipt_rejects_self_verification() {
         seal_terminal_receipt(&request, &support, body).expect_err("self-verification must fail");
 
     assert_eq!(error.code(), ContractErrorCode::InvalidContract);
-    assert_eq!(error.path(), "events[9].verifier_id");
+    assert_eq!(error.path(), "events[10].verifier_id");
 }
 
 #[test]
@@ -827,8 +888,8 @@ fn completed_receipt_rejects_usage_over_budget() {
     let request_digest = validate_request(&request, &support).expect("request should be valid");
     let mut body = completed_body(request_digest);
     body.usage.cost_micros = request.resource_budget.max_cost_micros + 1;
-    let RunEvent::Usage { usage, .. } = &mut body.events[7] else {
-        panic!("eighth event should record usage");
+    let RunEvent::Usage { usage, .. } = &mut body.events[8] else {
+        panic!("ninth event should record usage");
     };
     usage.cost_micros = body.usage.cost_micros;
 
@@ -866,9 +927,9 @@ fn an_allow_decision_cannot_authorize_an_effect_after_its_subject_changes() {
     let request_digest = validate_request(&request, &support).expect("request should be valid");
     let mut body = completed_body(request_digest);
     body.events.insert(
-        7,
+        8,
         RunEvent::ToolExecution {
-            sequence: 8,
+            sequence: 9,
             decision_id: "decision-tool-001".to_owned(),
             protected_effect_digest: digest('7'),
             action_digest: digest('6'),
@@ -876,7 +937,7 @@ fn an_allow_decision_cannot_authorize_an_effect_after_its_subject_changes() {
             evidence: vec![evidence(EvidenceType::ToolExecution, '5')],
         },
     );
-    for (index, event) in body.events.iter_mut().enumerate().skip(7) {
+    for (index, event) in body.events.iter_mut().enumerate().skip(8) {
         set_event_sequence(event, (index + 1) as u64);
     }
 
@@ -884,7 +945,7 @@ fn an_allow_decision_cannot_authorize_an_effect_after_its_subject_changes() {
         .expect_err("authority bound to the prior subject must be stale");
 
     assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
-    assert_eq!(error.path(), "events[7].decision_id");
+    assert_eq!(error.path(), "events[8].decision_id");
 }
 
 #[test]
@@ -911,8 +972,8 @@ fn mutation_requires_artifact_evidence() {
     let support = ContractSupport::new([policy()]);
     let request_digest = validate_request(&request, &support).expect("request should be valid");
     let mut body = completed_body(request_digest);
-    let RunEvent::Mutation { evidence, .. } = &mut body.events[6] else {
-        panic!("seventh event should be the mutation");
+    let RunEvent::Mutation { evidence, .. } = &mut body.events[7] else {
+        panic!("eighth event should be the mutation");
     };
     evidence[0].evidence_type = EvidenceType::CommandOutput;
 
@@ -920,7 +981,7 @@ fn mutation_requires_artifact_evidence() {
         .expect_err("mutation without artifact evidence must fail");
 
     assert_eq!(error.code(), ContractErrorCode::InvalidContract);
-    assert_eq!(error.path(), "events[6].evidence");
+    assert_eq!(error.path(), "events[7].evidence");
 }
 
 #[test]

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -314,6 +314,18 @@ fn request_rejects_an_unsafe_integer() {
 }
 
 #[test]
+fn request_accepts_the_jcs_safe_integer_maximum() {
+    let mut request = request();
+    request.resource_budget.max_cost_micros = 9_007_199_254_740_991;
+    request.resource_budget.max_elapsed_ms = 9_007_199_254_740_991;
+    request.resource_budget.max_model_tokens = 9_007_199_254_740_991;
+    request.resource_budget.max_tool_calls = 9_007_199_254_740_991;
+    let support = ContractSupport::new([policy()]);
+
+    validate_request(&request, &support).expect("safe integer maximum should be accepted");
+}
+
+#[test]
 fn raw_request_rejects_unknown_fields() {
     let mut value = serde_json::to_value(request()).expect("request should serialize");
     value
@@ -377,6 +389,27 @@ fn ask_decision_cannot_authorize_a_tool_execution() {
 }
 
 #[test]
+fn tool_execution_must_use_the_requested_capability() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::ToolExecution {
+        capability_digest, ..
+    } = &mut body.events[5]
+    else {
+        panic!("sixth event should be the tool execution");
+    };
+    *capability_digest = digest('6');
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("tool execution must match the requested capability");
+
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+    assert_eq!(error.path(), "events[5].capability_digest");
+}
+
+#[test]
 fn mutation_after_verification_makes_completion_stale() {
     let request = request();
     let support = ContractSupport::new([policy()]);
@@ -387,23 +420,38 @@ fn mutation_after_verification_makes_completion_stale() {
     body.resulting_subject_digest = later_subject.clone();
     body.events.insert(
         10,
-        RunEvent::Mutation {
+        RunEvent::ProtectedEffectDecision {
             sequence: 11,
-            decision_id: "decision-tool-001".to_owned(),
-            protected_effect_digest: digest('7'),
+            decision_id: "decision-later-mutation-001".to_owned(),
+            gate: Gate::Workflow,
+            protected_effect_digest: digest('4'),
+            subject_digest: prior_subject.clone(),
+            decision: Decision {
+                outcome: Outcome::Allow,
+                code: "workflow.mutation_authorized".to_owned(),
+                effects: vec!["mutate_subject".to_owned()],
+            },
+        },
+    );
+    body.events.insert(
+        11,
+        RunEvent::Mutation {
+            sequence: 12,
+            decision_id: "decision-later-mutation-001".to_owned(),
+            protected_effect_digest: digest('4'),
             before_subject_digest: prior_subject,
             after_subject_digest: later_subject.clone(),
             evidence: vec![evidence(EvidenceType::Artifact, '5')],
         },
     );
-    for (index, event) in body.events.iter_mut().enumerate().skip(11) {
+    for (index, event) in body.events.iter_mut().enumerate().skip(12) {
         set_event_sequence(event, (index + 1) as u64);
     }
     let RunEvent::ProtectedEffectDecision {
         protected_effect_digest,
         subject_digest,
         ..
-    } = &mut body.events[11]
+    } = &mut body.events[12]
     else {
         panic!("completion decision should follow the later mutation");
     };
@@ -432,6 +480,35 @@ fn illegal_lifecycle_transition_fails_closed() {
 
     assert_eq!(error.code(), ContractErrorCode::InvalidTransition);
     assert_eq!(error.path(), "events[0]");
+}
+
+#[test]
+fn completed_is_only_reachable_from_verifying() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    body.events.retain(|event| {
+        !matches!(
+            event,
+            RunEvent::StatusTransition {
+                to: AgentRunStatus::Executing | AgentRunStatus::Verifying,
+                ..
+            }
+        )
+    });
+    let Some(RunEvent::StatusTransition { from, .. }) = body.events.last_mut() else {
+        panic!("final event should be a status transition");
+    };
+    *from = AgentRunStatus::Planning;
+    for (index, event) in body.events.iter_mut().enumerate() {
+        set_event_sequence(event, (index + 1) as u64);
+    }
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("planning must not transition directly to completed");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidTransition);
 }
 
 #[test]
@@ -580,21 +657,51 @@ fn completed_receipt_rejects_usage_over_budget() {
 }
 
 #[test]
-fn completed_receipt_requires_plan_approval_evidence() {
+fn completed_receipt_allows_a_request_without_approval_context() {
+    let mut request = request();
+    request.approval_context.clear();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    body.events
+        .retain(|event| !matches!(event, RunEvent::ApprovalRecorded { .. }));
+    for (index, event) in body.events.iter_mut().enumerate() {
+        set_event_sequence(event, (index + 1) as u64);
+    }
+
+    let receipt = seal_terminal_receipt(&request, &support, body)
+        .expect("approval-free request should be able to complete");
+
+    verify_terminal_receipt(&request, &support, &receipt)
+        .expect("approval-free completed receipt should verify");
+}
+
+#[test]
+fn an_allow_decision_cannot_authorize_an_effect_after_its_subject_changes() {
     let request = request();
     let support = ContractSupport::new([policy()]);
     let request_digest = validate_request(&request, &support).expect("request should be valid");
     let mut body = completed_body(request_digest);
-    body.events.remove(2);
-    for (index, event) in body.events.iter_mut().enumerate().skip(2) {
+    body.events.insert(
+        7,
+        RunEvent::ToolExecution {
+            sequence: 8,
+            decision_id: "decision-tool-001".to_owned(),
+            protected_effect_digest: digest('7'),
+            action_digest: digest('6'),
+            capability_digest: digest('c'),
+            evidence: vec![evidence(EvidenceType::ToolExecution, '5')],
+        },
+    );
+    for (index, event) in body.events.iter_mut().enumerate().skip(7) {
         set_event_sequence(event, (index + 1) as u64);
     }
 
     let error = seal_terminal_receipt(&request, &support, body)
-        .expect_err("completion without plan approval evidence must fail");
+        .expect_err("authority bound to the prior subject must be stale");
 
-    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
-    assert_eq!(error.path(), "events");
+    assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+    assert_eq!(error.path(), "events[7].decision_id");
 }
 
 #[test]

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -1,0 +1,146 @@
+use gaap::contracts::{
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, ApprovalReference, CapabilityIdentity,
+    ContractErrorCode, ContractSupport, EvidenceReference, EvidenceType, PolicyIdentity,
+    ResourceBudget, Subject, SubjectKind, TaskSpec, VerificationIndependence,
+    VerificationRequirement, canonical_request_bytes, parse_agent_run_request_json,
+    validate_request,
+};
+
+fn digest(byte: char) -> String {
+    format!("sha256:{}", byte.to_string().repeat(64))
+}
+
+fn policy() -> PolicyIdentity {
+    PolicyIdentity {
+        name: "gaap.run-coordinator".to_owned(),
+        version: "0.1.0".to_owned(),
+        digest: digest('b'),
+    }
+}
+
+fn request() -> AgentRunRequest {
+    AgentRunRequest {
+        schema_version: AGENT_RUN_REQUEST_SCHEMA.to_owned(),
+        request_id: "request-001".to_owned(),
+        run_id: "run-001".to_owned(),
+        subject: Subject {
+            kind: SubjectKind::Repository,
+            locator: "https://example.invalid/repository".to_owned(),
+            digest: digest('a'),
+        },
+        requested_capability: CapabilityIdentity {
+            name: "change-code".to_owned(),
+            version: "1".to_owned(),
+            digest: digest('c'),
+        },
+        task: TaskSpec {
+            instructions: "Implement the approved change.".to_owned(),
+            constraints: vec!["Do not publish a release.".to_owned()],
+        },
+        policies: vec![policy()],
+        resource_budget: ResourceBudget {
+            max_cost_micros: 1_000_000,
+            max_elapsed_ms: 60_000,
+            max_model_tokens: 100_000,
+            max_tool_calls: 100,
+        },
+        approval_context: vec![ApprovalReference {
+            approval_id: "approval-001".to_owned(),
+            actor_id: "maintainer-001".to_owned(),
+            scope: "plan".to_owned(),
+            subject_digest: digest('d'),
+            evidence: EvidenceReference {
+                evidence_type: EvidenceType::Approval,
+                digest: digest('e'),
+                locator: None,
+            },
+        }],
+        required_verification: VerificationRequirement {
+            independence: VerificationIndependence::DifferentActor,
+            evidence_types: vec![EvidenceType::CommandOutput, EvidenceType::Artifact],
+        },
+    }
+}
+
+#[test]
+fn supported_request_returns_a_stable_canonical_digest() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let canonical = canonical_request_bytes(&request).expect("request should canonicalize");
+    let reparsed: AgentRunRequest =
+        serde_json::from_slice(&canonical).expect("canonical request should parse");
+
+    assert_eq!(reparsed, request);
+    assert_eq!(
+        request_digest,
+        "sha256:3d029feed0e1c4d89e58a4920401f2179f6af0fa24f59afeef33393808ed6632"
+    );
+}
+
+#[test]
+fn request_with_an_unknown_policy_fails_closed() {
+    let request = request();
+    let support = ContractSupport::default();
+
+    let error = validate_request(&request, &support).expect_err("unknown policy must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::UnknownPolicy);
+    assert_eq!(error.path(), "policies[0]");
+}
+
+#[test]
+fn request_rejects_an_unknown_schema_version() {
+    let mut request = request();
+    request.schema_version = "gaap.agent-run-request/9.9.9".to_owned();
+    let support = ContractSupport::new([policy()]);
+
+    let error = validate_request(&request, &support).expect_err("unknown schema must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::UnsupportedSchema);
+    assert_eq!(error.path(), "schema_version");
+}
+
+#[test]
+fn request_rejects_an_unsafe_integer() {
+    let mut request = request();
+    request.resource_budget.max_model_tokens = 9_007_199_254_740_992;
+    let support = ContractSupport::new([policy()]);
+
+    let error = validate_request(&request, &support).expect_err("unsafe integer must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "resource_budget.max_model_tokens");
+}
+
+#[test]
+fn raw_request_rejects_unknown_fields() {
+    let mut value = serde_json::to_value(request()).expect("request should serialize");
+    value
+        .as_object_mut()
+        .expect("request should be an object")
+        .insert("provider".to_owned(), serde_json::json!("openai"));
+
+    let error = parse_agent_run_request_json(
+        &serde_json::to_vec(&value).expect("request should serialize"),
+    )
+    .expect_err("unknown fields must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidJson);
+}
+
+#[test]
+fn raw_request_rejects_duplicate_fields() {
+    let json = serde_json::to_string(&request()).expect("request should serialize");
+    let duplicate = json.replacen(
+        "\"request_id\":",
+        "\"request_id\":\"shadow-request\",\"request_id\":",
+        1,
+    );
+
+    let error =
+        parse_agent_run_request_json(duplicate.as_bytes()).expect_err("duplicate fields must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidJson);
+}

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -389,6 +389,24 @@ fn ask_decision_cannot_authorize_a_tool_execution() {
 }
 
 #[test]
+fn block_decision_cannot_authorize_a_tool_execution() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::ProtectedEffectDecision { decision, .. } = &mut body.events[4] else {
+        panic!("fifth event should be the tool decision");
+    };
+    decision.outcome = Outcome::Block;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("block must not authorize execution");
+
+    assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+    assert_eq!(error.path(), "events[5].decision_id");
+}
+
+#[test]
 fn tool_execution_must_use_the_requested_capability() {
     let request = request();
     let support = ContractSupport::new([policy()]);
@@ -512,6 +530,115 @@ fn completed_is_only_reachable_from_verifying() {
 }
 
 #[test]
+fn lifecycle_allows_authority_and_verification_loops() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = terminal_body(
+        request_digest,
+        AgentRunStatus::Blocked,
+        "authority.required",
+    );
+    body.events = vec![
+        RunEvent::StatusTransition {
+            sequence: 1,
+            from: AgentRunStatus::Accepted,
+            to: AgentRunStatus::Planning,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 2,
+            from: AgentRunStatus::Planning,
+            to: AgentRunStatus::AwaitingAuthority,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 3,
+            from: AgentRunStatus::AwaitingAuthority,
+            to: AgentRunStatus::Planning,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 4,
+            from: AgentRunStatus::Planning,
+            to: AgentRunStatus::Executing,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 5,
+            from: AgentRunStatus::Executing,
+            to: AgentRunStatus::AwaitingAuthority,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 6,
+            from: AgentRunStatus::AwaitingAuthority,
+            to: AgentRunStatus::Executing,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 7,
+            from: AgentRunStatus::Executing,
+            to: AgentRunStatus::Verifying,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 8,
+            from: AgentRunStatus::Verifying,
+            to: AgentRunStatus::Executing,
+            reason: None,
+        },
+        RunEvent::StatusTransition {
+            sequence: 9,
+            from: AgentRunStatus::Executing,
+            to: AgentRunStatus::Verifying,
+            reason: None,
+        },
+        RunEvent::Usage {
+            sequence: 10,
+            usage: zero_usage(),
+        },
+        RunEvent::StatusTransition {
+            sequence: 11,
+            from: AgentRunStatus::Verifying,
+            to: AgentRunStatus::Blocked,
+            reason: Some("authority.required".to_owned()),
+        },
+    ];
+
+    let receipt = seal_terminal_receipt(&request, &support, body)
+        .expect("frozen lifecycle loops should be legal");
+
+    verify_terminal_receipt(&request, &support, &receipt)
+        .expect("looping lifecycle receipt should verify");
+}
+
+#[test]
+fn lifecycle_rejects_a_transition_after_a_terminal_state() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = terminal_body(request_digest, AgentRunStatus::Failed, "execution.failed");
+    let RunEvent::StatusTransition { to, reason, .. } = &mut body.events[2] else {
+        panic!("third event should be a status transition");
+    };
+    *to = AgentRunStatus::Blocked;
+    *reason = Some("authority.required".to_owned());
+    body.events.push(RunEvent::StatusTransition {
+        sequence: 4,
+        from: AgentRunStatus::Blocked,
+        to: AgentRunStatus::Failed,
+        reason: Some("execution.failed".to_owned()),
+    });
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("terminal states must reject later transitions");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidTransition);
+    assert_eq!(error.path(), "events[3]");
+}
+
+#[test]
 fn tampered_receipt_body_does_not_verify() {
     let request = request();
     let support = ContractSupport::new([policy()]);
@@ -585,6 +712,32 @@ fn raw_contracts_reject_unknown_terminal_and_evidence_types() {
 }
 
 #[test]
+fn raw_receipt_rejects_an_unknown_event_type() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let receipt = seal_terminal_receipt(
+        &request,
+        &support,
+        terminal_body(
+            request_digest,
+            AgentRunStatus::Blocked,
+            "authority.required",
+        ),
+    )
+    .expect("blocked receipt should seal");
+    let mut receipt_json = serde_json::to_value(receipt).expect("receipt should serialize");
+    receipt_json["body"]["events"][0]["event_type"] = serde_json::json!("provider_message");
+
+    let error = parse_terminal_run_receipt_json(
+        &serde_json::to_vec(&receipt_json).expect("receipt should serialize"),
+    )
+    .expect_err("unknown event type must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidJson);
+}
+
+#[test]
 fn receipt_rejects_a_gap_in_event_sequence() {
     let request = request();
     let support = ContractSupport::new([policy()]);
@@ -597,6 +750,36 @@ fn receipt_rejects_a_gap_in_event_sequence() {
 
     assert_eq!(error.code(), ContractErrorCode::InvalidContract);
     assert_eq!(error.path(), "events[5].sequence");
+}
+
+#[test]
+fn receipt_rejects_a_duplicate_event_sequence() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    set_event_sequence(&mut body.events[5], 5);
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("duplicate event sequence must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events[5].sequence");
+}
+
+#[test]
+fn receipt_rejects_reordered_events() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    body.events.swap(4, 5);
+
+    let error =
+        seal_terminal_receipt(&request, &support, body).expect_err("reordered events must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events[4].sequence");
 }
 
 #[test]

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -1,10 +1,13 @@
 use gaap::contracts::{
-    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, ApprovalReference, CapabilityIdentity,
-    ContractErrorCode, ContractSupport, EvidenceReference, EvidenceType, PolicyIdentity,
-    ResourceBudget, Subject, SubjectKind, TaskSpec, VerificationIndependence,
-    VerificationRequirement, canonical_request_bytes, parse_agent_run_request_json,
-    validate_request,
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, AgentRunStatus, ApprovalReference,
+    CapabilityIdentity, ContractErrorCode, ContractSupport, EvidenceReference, EvidenceType,
+    PolicyIdentity, ResourceBudget, ResourceUsage, RunEvent, Subject, SubjectKind,
+    TERMINAL_RUN_RECEIPT_SCHEMA, TaskSpec, TerminalRunReceiptBody, VerificationIndependence,
+    VerificationRequirement, VerificationVerdict, canonical_request_bytes,
+    parse_agent_run_request_json, parse_terminal_run_receipt_json, seal_terminal_receipt,
+    validate_request, verify_terminal_receipt,
 };
+use gaap::{Decision, Gate, Outcome};
 
 fn digest(byte: char) -> String {
     format!("sha256:{}", byte.to_string().repeat(64))
@@ -15,6 +18,20 @@ fn policy() -> PolicyIdentity {
         name: "gaap.run-coordinator".to_owned(),
         version: "0.1.0".to_owned(),
         digest: digest('b'),
+    }
+}
+
+fn approval() -> ApprovalReference {
+    ApprovalReference {
+        approval_id: "approval-001".to_owned(),
+        actor_id: "maintainer-001".to_owned(),
+        scope: "plan".to_owned(),
+        subject_digest: digest('d'),
+        evidence: EvidenceReference {
+            evidence_type: EvidenceType::Approval,
+            digest: digest('e'),
+            locator: None,
+        },
     }
 }
 
@@ -44,21 +61,203 @@ fn request() -> AgentRunRequest {
             max_model_tokens: 100_000,
             max_tool_calls: 100,
         },
-        approval_context: vec![ApprovalReference {
-            approval_id: "approval-001".to_owned(),
-            actor_id: "maintainer-001".to_owned(),
-            scope: "plan".to_owned(),
-            subject_digest: digest('d'),
-            evidence: EvidenceReference {
-                evidence_type: EvidenceType::Approval,
-                digest: digest('e'),
-                locator: None,
-            },
-        }],
+        approval_context: vec![approval()],
         required_verification: VerificationRequirement {
             independence: VerificationIndependence::DifferentActor,
             evidence_types: vec![EvidenceType::CommandOutput, EvidenceType::Artifact],
         },
+    }
+}
+
+fn evidence(evidence_type: EvidenceType, byte: char) -> EvidenceReference {
+    EvidenceReference {
+        evidence_type,
+        digest: digest(byte),
+        locator: None,
+    }
+}
+
+fn usage() -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: 200_000,
+        elapsed_ms: 2_000,
+        model_tokens: 2_500,
+        tool_calls: 1,
+    }
+}
+
+fn zero_usage() -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: 0,
+        elapsed_ms: 0,
+        model_tokens: 0,
+        tool_calls: 0,
+    }
+}
+
+fn completed_body(request_digest: String) -> TerminalRunReceiptBody {
+    let initial_subject = digest('a');
+    let resulting_subject = digest('f');
+    let protected_effect = digest('7');
+    TerminalRunReceiptBody {
+        schema_version: TERMINAL_RUN_RECEIPT_SCHEMA.to_owned(),
+        request_id: "request-001".to_owned(),
+        run_id: "run-001".to_owned(),
+        request_digest,
+        initial_subject_digest: initial_subject.clone(),
+        resulting_subject_digest: resulting_subject.clone(),
+        terminal_status: AgentRunStatus::Completed,
+        terminal_reason: "workflow.completion_authorized".to_owned(),
+        usage: usage(),
+        events: vec![
+            RunEvent::StatusTransition {
+                sequence: 1,
+                from: AgentRunStatus::Accepted,
+                to: AgentRunStatus::Planning,
+                reason: None,
+            },
+            RunEvent::PlanRecorded {
+                sequence: 2,
+                plan_digest: digest('d'),
+            },
+            RunEvent::ApprovalRecorded {
+                sequence: 3,
+                approval: approval(),
+            },
+            RunEvent::StatusTransition {
+                sequence: 4,
+                from: AgentRunStatus::Planning,
+                to: AgentRunStatus::Executing,
+                reason: None,
+            },
+            RunEvent::ProtectedEffectDecision {
+                sequence: 5,
+                decision_id: "decision-tool-001".to_owned(),
+                gate: Gate::Permission,
+                protected_effect_digest: protected_effect.clone(),
+                subject_digest: initial_subject.clone(),
+                decision: Decision {
+                    outcome: Outcome::Allow,
+                    code: "permission.policy_allowed".to_owned(),
+                    effects: vec![],
+                },
+            },
+            RunEvent::ToolExecution {
+                sequence: 6,
+                decision_id: "decision-tool-001".to_owned(),
+                protected_effect_digest: protected_effect.clone(),
+                action_digest: digest('8'),
+                capability_digest: digest('c'),
+                evidence: vec![evidence(EvidenceType::ToolExecution, '9')],
+            },
+            RunEvent::Mutation {
+                sequence: 7,
+                decision_id: "decision-tool-001".to_owned(),
+                protected_effect_digest: protected_effect,
+                before_subject_digest: initial_subject,
+                after_subject_digest: resulting_subject.clone(),
+                evidence: vec![evidence(EvidenceType::Artifact, '0')],
+            },
+            RunEvent::Usage {
+                sequence: 8,
+                usage: usage(),
+            },
+            RunEvent::StatusTransition {
+                sequence: 9,
+                from: AgentRunStatus::Executing,
+                to: AgentRunStatus::Verifying,
+                reason: None,
+            },
+            RunEvent::Verification {
+                sequence: 10,
+                subject_digest: resulting_subject.clone(),
+                implementer_id: "executor-001".to_owned(),
+                verifier_id: "verifier-001".to_owned(),
+                verdict: VerificationVerdict::Pass,
+                evidence: vec![
+                    evidence(EvidenceType::CommandOutput, '1'),
+                    evidence(EvidenceType::Artifact, '2'),
+                ],
+            },
+            RunEvent::ProtectedEffectDecision {
+                sequence: 11,
+                decision_id: "decision-completion-001".to_owned(),
+                gate: Gate::Workflow,
+                protected_effect_digest: resulting_subject.clone(),
+                subject_digest: resulting_subject,
+                decision: Decision {
+                    outcome: Outcome::Allow,
+                    code: "workflow.completion_authorized".to_owned(),
+                    effects: vec!["record_completion".to_owned()],
+                },
+            },
+            RunEvent::StatusTransition {
+                sequence: 12,
+                from: AgentRunStatus::Verifying,
+                to: AgentRunStatus::Completed,
+                reason: Some("workflow.completion_authorized".to_owned()),
+            },
+        ],
+    }
+}
+
+fn set_event_sequence(event: &mut RunEvent, value: u64) {
+    match event {
+        RunEvent::StatusTransition { sequence, .. }
+        | RunEvent::PlanRecorded { sequence, .. }
+        | RunEvent::ApprovalRecorded { sequence, .. }
+        | RunEvent::ProtectedEffectDecision { sequence, .. }
+        | RunEvent::ToolExecution { sequence, .. }
+        | RunEvent::Mutation { sequence, .. }
+        | RunEvent::Verification { sequence, .. }
+        | RunEvent::Usage { sequence, .. }
+        | RunEvent::Interruption { sequence, .. } => *sequence = value,
+    }
+}
+
+fn terminal_body(
+    request_digest: String,
+    terminal_status: AgentRunStatus,
+    terminal_reason: &str,
+) -> TerminalRunReceiptBody {
+    let mut events = vec![
+        RunEvent::StatusTransition {
+            sequence: 1,
+            from: AgentRunStatus::Accepted,
+            to: AgentRunStatus::Planning,
+            reason: None,
+        },
+        RunEvent::Usage {
+            sequence: 2,
+            usage: zero_usage(),
+        },
+    ];
+    if terminal_status == AgentRunStatus::Interrupted {
+        events.push(RunEvent::Interruption {
+            sequence: 3,
+            actor_id: Some("operator-001".to_owned()),
+            reason: terminal_reason.to_owned(),
+            evidence: evidence(EvidenceType::Interruption, '4'),
+        });
+    }
+    let terminal_sequence = (events.len() + 1) as u64;
+    events.push(RunEvent::StatusTransition {
+        sequence: terminal_sequence,
+        from: AgentRunStatus::Planning,
+        to: terminal_status,
+        reason: Some(terminal_reason.to_owned()),
+    });
+    TerminalRunReceiptBody {
+        schema_version: TERMINAL_RUN_RECEIPT_SCHEMA.to_owned(),
+        request_id: "request-001".to_owned(),
+        run_id: "run-001".to_owned(),
+        request_digest,
+        initial_subject_digest: digest('a'),
+        resulting_subject_digest: digest('a'),
+        terminal_status,
+        terminal_reason: terminal_reason.to_owned(),
+        usage: zero_usage(),
+        events,
     }
 }
 
@@ -143,4 +342,322 @@ fn raw_request_rejects_duplicate_fields() {
         parse_agent_run_request_json(duplicate.as_bytes()).expect_err("duplicate fields must fail");
 
     assert_eq!(error.code(), ContractErrorCode::InvalidJson);
+}
+
+#[test]
+fn completed_receipt_is_sealed_and_verified_against_the_request() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let body = completed_body(request_digest);
+
+    let receipt =
+        seal_terminal_receipt(&request, &support, body).expect("completed receipt should seal");
+
+    assert!(receipt.receipt_digest.starts_with("sha256:"));
+    verify_terminal_receipt(&request, &support, &receipt).expect("sealed receipt should verify");
+}
+
+#[test]
+fn ask_decision_cannot_authorize_a_tool_execution() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::ProtectedEffectDecision { decision, .. } = &mut body.events[4] else {
+        panic!("fifth event should be the tool decision");
+    };
+    decision.outcome = Outcome::Ask;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("ask must not authorize execution");
+
+    assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+    assert_eq!(error.path(), "events[5].decision_id");
+}
+
+#[test]
+fn mutation_after_verification_makes_completion_stale() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let prior_subject = digest('f');
+    let later_subject = digest('6');
+    body.resulting_subject_digest = later_subject.clone();
+    body.events.insert(
+        10,
+        RunEvent::Mutation {
+            sequence: 11,
+            decision_id: "decision-tool-001".to_owned(),
+            protected_effect_digest: digest('7'),
+            before_subject_digest: prior_subject,
+            after_subject_digest: later_subject.clone(),
+            evidence: vec![evidence(EvidenceType::Artifact, '5')],
+        },
+    );
+    for (index, event) in body.events.iter_mut().enumerate().skip(11) {
+        set_event_sequence(event, (index + 1) as u64);
+    }
+    let RunEvent::ProtectedEffectDecision {
+        protected_effect_digest,
+        subject_digest,
+        ..
+    } = &mut body.events[11]
+    else {
+        panic!("completion decision should follow the later mutation");
+    };
+    *protected_effect_digest = later_subject.clone();
+    *subject_digest = later_subject;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("later mutation must stale verification");
+
+    assert_eq!(error.code(), ContractErrorCode::StaleVerification);
+}
+
+#[test]
+fn illegal_lifecycle_transition_fails_closed() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::StatusTransition { to, .. } = &mut body.events[0] else {
+        panic!("first event should be a status transition");
+    };
+    *to = AgentRunStatus::Executing;
+
+    let error =
+        seal_terminal_receipt(&request, &support, body).expect_err("illegal transition must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidTransition);
+    assert_eq!(error.path(), "events[0]");
+}
+
+#[test]
+fn tampered_receipt_body_does_not_verify() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut receipt = seal_terminal_receipt(&request, &support, completed_body(request_digest))
+        .expect("completed receipt should seal");
+    receipt.body.terminal_reason = "tampered".to_owned();
+
+    let error =
+        verify_terminal_receipt(&request, &support, &receipt).expect_err("tampering must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::ReceiptTampering);
+    assert_eq!(error.path(), "receipt_digest");
+}
+
+#[test]
+fn blocked_failed_and_interrupted_are_distinct_valid_outcomes() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+
+    for (status, reason) in [
+        (AgentRunStatus::Blocked, "authority.required"),
+        (AgentRunStatus::Failed, "execution.failed"),
+        (AgentRunStatus::Interrupted, "operator.interrupted"),
+    ] {
+        let receipt = seal_terminal_receipt(
+            &request,
+            &support,
+            terminal_body(request_digest.clone(), status, reason),
+        )
+        .expect("terminal outcome should seal");
+
+        assert_eq!(receipt.body.terminal_status, status);
+        assert_eq!(receipt.body.terminal_reason, reason);
+    }
+}
+
+#[test]
+fn raw_contracts_reject_unknown_terminal_and_evidence_types() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let receipt = seal_terminal_receipt(
+        &request,
+        &support,
+        terminal_body(
+            request_digest,
+            AgentRunStatus::Blocked,
+            "authority.required",
+        ),
+    )
+    .expect("blocked receipt should seal");
+    let mut receipt_json = serde_json::to_value(receipt).expect("receipt should serialize");
+    receipt_json["body"]["terminal_status"] = serde_json::json!("paused");
+
+    let terminal_error = parse_terminal_run_receipt_json(
+        &serde_json::to_vec(&receipt_json).expect("receipt should serialize"),
+    )
+    .expect_err("unknown terminal status must fail");
+
+    let mut request_json = serde_json::to_value(request).expect("request should serialize");
+    request_json["required_verification"]["evidence_types"][0] = serde_json::json!("provider_log");
+    let evidence_error = parse_agent_run_request_json(
+        &serde_json::to_vec(&request_json).expect("request should serialize"),
+    )
+    .expect_err("unknown evidence type must fail");
+
+    assert_eq!(terminal_error.code(), ContractErrorCode::InvalidJson);
+    assert_eq!(evidence_error.code(), ContractErrorCode::InvalidJson);
+}
+
+#[test]
+fn receipt_rejects_a_gap_in_event_sequence() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    set_event_sequence(&mut body.events[5], 7);
+
+    let error =
+        seal_terminal_receipt(&request, &support, body).expect_err("sequence gap must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events[5].sequence");
+}
+
+#[test]
+fn receipt_rejects_a_different_request_identity() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    body.request_id = "request-other".to_owned();
+
+    let error =
+        seal_terminal_receipt(&request, &support, body).expect_err("mismatched request must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+    assert_eq!(error.path(), "body.request_id");
+}
+
+#[test]
+fn completed_receipt_rejects_self_verification() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::Verification {
+        implementer_id,
+        verifier_id,
+        ..
+    } = &mut body.events[9]
+    else {
+        panic!("ninth event should be verification");
+    };
+    *verifier_id = implementer_id.clone();
+
+    let error =
+        seal_terminal_receipt(&request, &support, body).expect_err("self-verification must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events[9].verifier_id");
+}
+
+#[test]
+fn completed_receipt_rejects_usage_over_budget() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    body.usage.cost_micros = request.resource_budget.max_cost_micros + 1;
+    let RunEvent::Usage { usage, .. } = &mut body.events[7] else {
+        panic!("eighth event should record usage");
+    };
+    usage.cost_micros = body.usage.cost_micros;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("over-budget completion must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "body.usage");
+}
+
+#[test]
+fn completed_receipt_requires_plan_approval_evidence() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    body.events.remove(2);
+    for (index, event) in body.events.iter_mut().enumerate().skip(2) {
+        set_event_sequence(event, (index + 1) as u64);
+    }
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("completion without plan approval evidence must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events");
+}
+
+#[test]
+fn stale_subject_decision_cannot_authorize_an_effect() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::ProtectedEffectDecision { subject_digest, .. } = &mut body.events[4] else {
+        panic!("fifth event should be the tool decision");
+    };
+    *subject_digest = digest('6');
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("stale decision subject must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events[4].subject_digest");
+}
+
+#[test]
+fn mutation_requires_artifact_evidence() {
+    let request = request();
+    let support = ContractSupport::new([policy()]);
+    let request_digest = validate_request(&request, &support).expect("request should be valid");
+    let mut body = completed_body(request_digest);
+    let RunEvent::Mutation { evidence, .. } = &mut body.events[6] else {
+        panic!("seventh event should be the mutation");
+    };
+    evidence[0].evidence_type = EvidenceType::CommandOutput;
+
+    let error = seal_terminal_receipt(&request, &support, body)
+        .expect_err("mutation without artifact evidence must fail");
+
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "events[6].evidence");
+}
+
+#[test]
+fn canonical_request_is_independent_of_json_property_order() {
+    let request = request();
+    let canonical = canonical_request_bytes(&request).expect("request should canonicalize");
+    let value: serde_json::Value =
+        serde_json::from_slice(&canonical).expect("canonical request should parse");
+    let object = value.as_object().expect("request should be an object");
+    let reversed_fields = object
+        .iter()
+        .rev()
+        .map(|(key, value)| {
+            format!(
+                "{}:{}",
+                serde_json::to_string(key).expect("key should serialize"),
+                serde_json::to_string(value).expect("value should serialize")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let reordered = format!("{{{reversed_fields}}}");
+    let parsed =
+        parse_agent_run_request_json(reordered.as_bytes()).expect("reordered request should parse");
+
+    assert_eq!(
+        canonical_request_bytes(&parsed).expect("reordered request should canonicalize"),
+        canonical
+    );
 }

--- a/tests/schema_contracts.rs
+++ b/tests/schema_contracts.rs
@@ -1,0 +1,106 @@
+use std::fs;
+use std::path::PathBuf;
+
+use gaap::contracts::{
+    AgentRunStatus, ContractSupport, agent_run_request_schema, parse_agent_run_request_json,
+    parse_terminal_run_receipt_json, terminal_run_receipt_schema, validate_request,
+    verify_terminal_receipt,
+};
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn generated_contract_schemas_match_the_committed_documents() {
+    for (path, generated) in [
+        (
+            "schemas/agent-run/v0.1.0/agent-run-request.schema.json",
+            agent_run_request_schema(),
+        ),
+        (
+            "schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json",
+            terminal_run_receipt_schema(),
+        ),
+    ] {
+        let expected = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&generated).expect("schema should serialize")
+        );
+        let actual = fs::read_to_string(repository_root().join(path))
+            .unwrap_or_else(|error| panic!("could not read {path}: {error}"));
+
+        assert_eq!(actual, expected, "generated schema drifted: {path}");
+    }
+}
+
+#[test]
+fn committed_examples_match_schemas_and_semantic_contracts() {
+    let root = repository_root();
+    let request_path = root.join("examples/contracts/v0.1.0/agent-run-request.json");
+    let request_bytes = fs::read(&request_path).expect("request example should be readable");
+    let request_value: serde_json::Value =
+        serde_json::from_slice(&request_bytes).expect("request example should be JSON");
+    let request_validator = jsonschema::validator_for(&agent_run_request_schema())
+        .expect("request schema should compile");
+    request_validator
+        .validate(&request_value)
+        .unwrap_or_else(|error| panic!("request example does not match schema: {error}"));
+    let request =
+        parse_agent_run_request_json(&request_bytes).expect("request example should parse");
+    let support = ContractSupport::new(request.policies.clone());
+    validate_request(&request, &support).expect("request example should validate");
+
+    let receipt_validator = jsonschema::validator_for(&terminal_run_receipt_schema())
+        .expect("receipt schema should compile");
+    let scenarios = [
+        (
+            "completed.json",
+            AgentRunStatus::Completed,
+            "workflow.completion_authorized",
+        ),
+        (
+            "blocked.json",
+            AgentRunStatus::Blocked,
+            "authority.required",
+        ),
+        ("failed.json", AgentRunStatus::Failed, "execution.failed"),
+        (
+            "interrupted.json",
+            AgentRunStatus::Interrupted,
+            "operator.interrupted",
+        ),
+        (
+            "budget-exhausted.json",
+            AgentRunStatus::Blocked,
+            "runtime.hard_stop",
+        ),
+        (
+            "denied-effect.json",
+            AgentRunStatus::Blocked,
+            "permission.denied",
+        ),
+        (
+            "stale-verification.json",
+            AgentRunStatus::Blocked,
+            "verification.stale_subject",
+        ),
+    ];
+    for (file_name, expected_status, expected_reason) in scenarios {
+        let path = root.join("examples/contracts/v0.1.0").join(file_name);
+        let bytes = fs::read(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let value: serde_json::Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|error| panic!("{file_name} should be JSON: {error}"));
+        receipt_validator
+            .validate(&value)
+            .unwrap_or_else(|error| panic!("{file_name} does not match schema: {error}"));
+        let receipt = parse_terminal_run_receipt_json(&bytes)
+            .unwrap_or_else(|error| panic!("{file_name} should parse: {error}"));
+        verify_terminal_receipt(&request, &support, &receipt)
+            .unwrap_or_else(|error| panic!("{file_name} should verify: {error}"));
+
+        assert_eq!(receipt.body.terminal_status, expected_status, "{file_name}");
+        assert_eq!(receipt.body.terminal_reason, expected_reason, "{file_name}");
+    }
+}


### PR DESCRIPTION
## Summary

- freeze provider-neutral Agent Run Request and Terminal Run Receipt 0.1.0 Rust contracts
- enforce exact policy support, RFC 8785 digests, lifecycle legality, ordered evidence, subject-current effect authority, independent verification, usage, and tamper checks
- publish Draft 2020-12 schemas, one request fixture, seven terminal-outcome fixtures, ADR 0003, and contract documentation
- preserve the existing RunCoordinator and RunInvariant process protocol without adding runtime, adapters, persistence, recovery, signing, or ThreadLoop coupling

## Verification

- `cargo run --locked --example generate-contract-schemas -- --check`
- `cargo run --locked --example generate-contract-examples -- --check`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo build --locked`
- pinned RunInvariant subject reproduction at `e3eb0dfb36390c32d2cd84bbbdf903f5dc55de44` matches the committed 35/35 evidence byte-for-byte
- final DX audit: no findings
- final Standards and Spec reviews: no actionable findings

Closes #9