### PR TITLE
feat(contracts): define Protected Effect Request and Result v0.1

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,38 @@ _Avoid_: Provider request, workflow run request
 One bounded execution governed through GAAP's integrity decisions that produces exactly one Terminal Run Receipt.
 _Avoid_: ThreadLoop Workflow Run, provider session
 
+**Protected effect**:
+One externally observable operation that must be proposed, decided, and recorded against an exact Agent Run, subject, and capability before a runtime may proceed.
+_Avoid_: Tool call, provider action, authorized action
+
+**Protected Effect Request**:
+The immutable, versioned description of one proposed protected effect, including its parent-run binding, current subject, normalized operation and input digest, requested scopes, identities, and repeatability.
+_Avoid_: Tool invocation, permission grant
+
+**Protected Effect Result**:
+The content-addressed record that binds one exact Protected Effect Request to the decisive RunCoordinator decision, observed identities, execution status, effect-local usage, and effect evidence.
+_Avoid_: Tool response, Terminal Run Receipt
+
+**Execution status**:
+The closed result classification that distinguishes executed, awaiting-authority, denied, failed, interrupted, and unknown-outcome effects without changing the RunCoordinator decision.
+_Avoid_: Decision, lifecycle state
+
+**Observed subject**:
+The repository or artifact identity measured immediately before or after a protected-effect attempt and recorded independently from the subject proposed in the request.
+_Avoid_: Requested subject, assumed workspace
+
+**Schema drift**:
+A denied pre-execution observation that the requested tool-schema digest is no longer current.
+_Avoid_: Parse error, provider incompatibility
+
+**Repeatability**:
+The request's declaration that an identical effect is repeatable, idempotent, or non-repeatable; it informs a future runtime but never initiates retry.
+_Avoid_: Retry policy, execution status
+
+**Effect evidence reference**:
+Content-addressed metadata naming one observed effect fact by closed type, digest, and optional locator without embedding raw output or secrets.
+_Avoid_: Raw output, provider message
+
 **Terminal Run Receipt**:
 The content-addressed record of an Agent Run's terminal status, decisions, observed effects, evidence, resource usage, and exact resulting subject.
 _Avoid_: Log, transcript, Trial result

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ cargo test --locked
 cargo build --locked
 cargo run --locked --example generate-contract-schemas -- --check
 cargo run --locked --example generate-contract-examples -- --check
+cargo run --locked --example generate-protected-effect-examples -- --check
 ```
 
 Changes to `RunCoordinator` decisions must also be tested through the pinned
@@ -29,6 +30,11 @@ hand or update it to make a failing implementation appear conformant.
   to an existing version.
 - Version Agent Run contracts when adding or changing a field, lifecycle state,
   event type, evidence type, canonicalization rule, or validation rule.
+- Version Protected Effect contracts independently when adding or changing a
+  field, operation family, scope shape, execution status, evidence type,
+  repeatability class, canonicalization rule, or validation rule.
+- When a closed enum changes, update every exhaustive validator, schema,
+  generator, example, test, and documentation consumer in the same change.
 - Regenerate schemas and examples intentionally; never edit their digests or
   generated schema documents to hide contract drift.
 - Keep implementation evidence separate from claims about a complete agent

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ tools, repository mutations, sandboxes, or verifiers.
 | Path or interface | Current behavior | Developer use |
 | --- | --- | --- |
 | [`RunCoordinator::evaluate(gate, input)`](./src/lib.rs) | Accepts a typed `Gate` and normalized JSON input, then returns an `allow`, `ask`, or `block` decision with a code and effects. | Put one deterministic decision module behind future provider, tool, and runtime adapters. |
-| [`gaap::contracts`](./src/contracts) | Defines and validates the provider-neutral Agent Run Request, lifecycle, ordered event ledger, and Terminal Run Receipt `0.1.0`. | Integrate against canonical Rust types or generated language-neutral JSON Schemas without importing provider SDK types. |
+| [`gaap::contracts`](./src/contracts) | Defines and validates provider-neutral Agent Run and Protected Effect `0.1.0` contracts. | Parse, canonicalize, validate, seal, and verify immutable contract values without importing provider SDK types. |
+| [`gaap::contracts::protected_effect`](./src/contracts/protected_effect) | Defines typed effect scopes, request binding, result-state invariants, evidence references, and replay/tamper checks. It performs no effect or policy evaluation. | Integrate a future executor at one small contract seam while keeping `RunCoordinator` authoritative. |
 | [`schemas/agent-run/v0.1.0`](./schemas/agent-run/v0.1.0) | Freezes Draft 2020-12 request and receipt schemas with strict fields, versions, enums, digests, and safe integers. | Generate or validate cross-language contract documents. |
+| [`schemas/protected-effect/v0.1.0`](./schemas/protected-effect/v0.1.0) | Freezes separate Draft 2020-12 Protected Effect Request and Result schemas. | Validate cross-language effect proposals and observed outcomes. |
 | [`examples/contracts/v0.1.0`](./examples/contracts/v0.1.0) | Provides one request and seven digest-valid terminal outcomes. | Inspect completed and failure-path contract behavior. |
+| [`examples/contracts/protected-effect/v0.1.0`](./examples/contracts/protected-effect/v0.1.0) | Provides one effect request and eight digest-valid result scenarios. | Inspect executed, non-executed, drift, failure, interruption, and unknown-outcome behavior. |
 | `gaap run-invariant` | Reads a RunInvariant request from stdin and writes one response to stdout. | Test the Rust coordinator without importing its crate or depending on Rust. |
 | [`evidence/run-invariant-subject-v0.1.0.json`](./evidence/run-invariant-subject-v0.1.0.json) | Records the Rust subject's exact 35/35 result and request digest. | Reproduce the current external conformance claim. |
 | [`docs/patterns`](./docs/patterns) | Defines the five integrity gates and their operating intent. | Design the larger agent-run lifecycle and review other systems. |
@@ -37,18 +40,27 @@ Implemented and tested now:
 - independent, subject-bound, evidence-bearing verification;
 - fail-closed usage accounting and bounded overage approval;
 - separate mutation and completion authorization;
-- a language-neutral RunInvariant process adapter; and
+- a language-neutral RunInvariant process adapter;
 - a 35/35 black-box conformance packet for the frozen protocol;
 - provider-neutral Agent Run Request and Terminal Run Receipt Rust types;
 - RFC 8785 canonical request and receipt-body digests;
 - fail-closed policy, lifecycle, evidence, subject-freshness, and usage validation;
+- provider-neutral Protected Effect Request and Result Rust types with typed
+  filesystem, process, network, and external-service scopes;
+- parent-bound request digests and sealed, replay-resistant result digests;
+- fail-closed decision/status, observed-identity, drift, evidence, and
+  non-execution invariants;
 - generated Draft 2020-12 JSON Schemas; and
-- completed, blocked, failed, interrupted, budget-exhausted, denied-effect, and stale-verification examples.
+- Agent Run terminal examples plus completed/executed, denied,
+  awaiting-authority, failed, interrupted, stale-subject, schema-drift, and
+  unknown-outcome Protected Effect examples.
 
 Not implemented yet:
 
-- an open-ended model and tool execution loop;
+- a bounded or open-ended model and tool execution loop;
 - OpenAI, Anthropic, MCP, or other provider adapters;
+- Protected Effect execution, retry orchestration, reconciliation, or
+  persistence;
 - repository mutation interception;
 - approval persistence, revocation, or delegated authority;
 - sandbox, budget-meter, verifier, or evidence-ledger adapters; and
@@ -70,6 +82,7 @@ cargo clippy --locked --all-targets -- -D warnings
 cargo build --locked
 cargo run --locked --example generate-contract-schemas -- --check
 cargo run --locked --example generate-contract-examples -- --check
+cargo run --locked --example generate-protected-effect-examples -- --check
 ```
 
 Inspect the CLI:
@@ -124,11 +137,17 @@ Architecture decisions:
 - [`0001: Own the agent loop`](./docs/adr/0001-own-the-agent-loop.md)
 - [`0002: Use an external conformance seam`](./docs/adr/0002-run-invariant-process-seam.md)
 - [`0003: Freeze the Agent Run contract as canonical evidence`](./docs/adr/0003-freeze-agent-run-contract.md)
+- [`0004: Separate Protected Effect contracts from execution`](./docs/adr/0004-protected-effect-contract-boundary.md)
 
 The normative contract guide is
 [`Agent Run Contract 0.1.0`](./docs/contracts/agent-run-v0.1.md). Contract
 receipts are content-addressed but not signed; they provide integrity and
 interoperability, not producer authenticity.
+
+The inner effect boundary is defined by
+[`Protected Effect Contract 0.1.0`](./docs/contracts/protected-effect-v0.1.md).
+Its validators check contract consistency; they do not replace
+`RunCoordinator`, execute effects, or implement the bounded runtime.
 
 ## Pattern Library
 

--- a/docs/adr/0004-protected-effect-contract-boundary.md
+++ b/docs/adr/0004-protected-effect-contract-boundary.md
@@ -1,0 +1,33 @@
+# ADR 0004: Separate Protected Effect Contracts From Execution
+
+Status: Accepted
+
+## Decision
+
+GAAP will represent each proposed protected effect and its observed outcome as
+separate provider-neutral, versioned, immutable contracts. The request binds
+the effect to its exact parent run, current subject, capability, policy,
+budget, requested scopes, sandbox profile, normalized input digest, and
+repeatability. The result envelopes a canonical body that binds the exact
+request to the decisive `RunCoordinator` decision, observed identities,
+execution status, usage, and content-addressed evidence.
+
+Contract validation checks structural and identity consistency only.
+`RunCoordinator` remains the sole decision authority. Effect execution,
+cross-effect sequencing, persistence, retry, recovery, and reconciliation are
+owned by the later bounded runtime, while the Terminal Run Receipt remains the
+authority for full lifecycle chronology.
+
+## Consequences
+
+- Providers and transports can exchange effects without importing SDK types.
+- An `ask` or `block` decision cannot be represented as an executed effect.
+- Stale-subject and schema-drift denials preserve observations without
+  implying that an executor ran.
+- `unknown_outcome` remains distinct from failure, so a non-repeatable request
+  requires reconciliation rather than automatic retry.
+- Result digests provide tamper evidence and replay binding, not producer
+  authenticity.
+- New fields, operation families, statuses, evidence types, or repeatability
+  classes require a new Protected Effect contract version and updates to every
+  exhaustive consumer.

--- a/docs/contracts/agent-run-v0.1.md
+++ b/docs/contracts/agent-run-v0.1.md
@@ -83,6 +83,11 @@ numbered from `1`. The closed event union records:
 Evidence entries contain a closed evidence type, content digest, and optional
 locator. Raw tool output and provider messages are not embedded.
 
+Every `protected_effect_digest` in a decision, tool-execution, or mutation
+event is the RFC 8785 canonical Protected Effect Request digest defined by the
+separate `gaap.protected-effect-request/0.1.0` contract. The Terminal Run
+Receipt remains authoritative for the ordered, multi-gate event chronology.
+
 ## Canonicalization And Digests
 
 GAAP uses RFC 8785 JSON Canonicalization Scheme bytes and lowercase SHA-256:
@@ -91,6 +96,9 @@ GAAP uses RFC 8785 JSON Canonicalization Scheme bytes and lowercase SHA-256:
 request_digest = SHA-256(JCS(AgentRunRequest))
 receipt_digest = SHA-256(JCS(TerminalRunReceiptBody))
 ```
+
+Protected Effect Request and Result digests are versioned separately and are
+defined in [`Protected Effect Contract 0.1.0`](./protected-effect-v0.1.md).
 
 Contract numbers are non-negative integers no larger than
 `9_007_199_254_740_991`; floating-point values are absent. Array order remains
@@ -134,5 +142,6 @@ Evidence Packet.
 ```bash
 cargo run --locked --example generate-contract-schemas -- --check
 cargo run --locked --example generate-contract-examples -- --check
+cargo run --locked --example generate-protected-effect-examples -- --check
 cargo test --locked --test contracts --test schema_contracts
 ```

--- a/docs/contracts/protected-effect-v0.1.md
+++ b/docs/contracts/protected-effect-v0.1.md
@@ -85,8 +85,9 @@ Network protocols are `tcp`, `udp`, `http`, and `https`.
 
 The run ID, Agent Run Request digest, capability, policy identities, and
 resource-budget digest must exactly match a validated `AgentRunRequest`.
-Effect-specific approval references identify evidence. They do not authorize
-execution by themselves.
+Effect-specific approval references identify evidence bound to the Protected
+Effect Request's current subject digest. They do not authorize execution by
+themselves.
 
 `RunCoordinator` remains the sole decision authority. The contract validator
 does not recompute policy or reinterpret a decision code.
@@ -124,6 +125,8 @@ and sandbox identities, a reason, and typed evidence references.
 The decisive decision record contains its ID, gate, exact Protected Effect
 Request digest, observed subject digest, and the existing `Decision`. Full
 multi-gate chronology remains in the Terminal Run Receipt event ledger.
+An attempted effect requires an `allow` decision from the `permission` gate;
+an `allow` from another gate cannot authorize execution.
 
 ### Decision And Execution Matrix
 
@@ -144,7 +147,8 @@ An observation result with a known post-effect subject preserves the subject
 digest. A mutation result with a known post-effect subject requires
 both mutation and artifact evidence even if the resulting digest is unchanged.
 Known `process` execution and failure records contain exactly one exit code or
-signal plus exit evidence.
+signal plus exit evidence. Non-process results cannot contain an exit status or
+exit evidence.
 
 Process exits are a tagged union:
 

--- a/docs/contracts/protected-effect-v0.1.md
+++ b/docs/contracts/protected-effect-v0.1.md
@@ -1,0 +1,237 @@
+# Protected Effect Contract 0.1.0
+
+This contract defines the provider-neutral JSON boundary for proposing one
+protected effect inside an Agent Run and recording whether it was declined,
+attempted, or completed. It defines immutable data and consistency validation;
+it does not execute an effect, evaluate policy, grant authority, persist state,
+retry work, reconcile an unknown outcome, or enforce a sandbox.
+
+## Contract Documents
+
+- `gaap.protected-effect-request/0.1.0` describes one proposed effect.
+- `gaap.protected-effect-result/0.1.0` records the decisive coordinator
+  decision and the observed execution outcome.
+- The generated JSON Schemas use Draft 2020-12 and reject unknown fields.
+- The Rust types, parsers, validators, canonicalizers, sealing function, and
+  verifier are exposed through `gaap::contracts`.
+
+The generated schemas live under `schemas/protected-effect/v0.1.0`. A request
+and eight digest-valid result scenarios live under
+`examples/contracts/protected-effect/v0.1.0`.
+
+## Protected Effect Request
+
+A `ProtectedEffectRequest` binds a proposed effect to:
+
+- an effect ID and one-based JCS-safe sequence within one Agent Run;
+- the run ID and exact canonical Agent Run Request digest;
+- the current proposed repository or artifact subject;
+- a closed operation family and lower-snake dotted operation name;
+- the exact capability and optional tool-schema digest;
+- a digest of normalized provider input and bounded non-secret metadata;
+- typed filesystem, process, network, or external-service scopes;
+- the parent run's exact policy identities and resource-budget digest;
+- approval evidence identities, a sandbox profile, and an idempotency key; and
+- closed repeatability and expected effect classifications.
+
+The expected effect classes are `observation` and `mutation`.
+
+The subject is the proposed current subject. It may differ from the parent
+Agent Run Request's initial subject after an earlier mutation. The effect
+validator does not decide whether that change is authorized; the result must
+record what was observed immediately before execution.
+
+`effect_sequence` establishes identity and position, not cross-effect
+ordering. The bounded runtime defined after this contract is responsible for
+contiguous sequencing, persistence, and recovery.
+
+### Input And Metadata
+
+Provider input is normalized outside the contract and is not embedded:
+
+```text
+input_digest = SHA-256(JCS(normalized_input))
+```
+
+`input_metadata` may contain at most 32 entries. Names are unique values of
+1–64 characters; values are 1–256 characters. Producers must
+not put secrets or raw provider input in metadata. The validator can enforce
+shape and bounds, but it cannot infer whether arbitrary text is sensitive.
+
+### Operations And Scopes
+
+The closed operation families are `filesystem`, `process`, `network`, and
+`external_service`. A normalized operation begins with its family and uses
+lower-snake dotted segments, such as `process.spawn`.
+
+Requested scopes are a tagged union:
+
+```json
+{"scope_type":"filesystem","root":"/workspace","access":["read","modify"],"recursive":true}
+{"scope_type":"process","executable":"/usr/bin/cargo","working_directory":"/workspace"}
+{"scope_type":"network","protocol":"https","host":"crates.io","port":443}
+{"scope_type":"external_service","service":"github","operation":"pull_request.comment","resource":"nnennandukwe/repo#22"}
+```
+
+A scope describes the authority being requested; it never grants that
+authority by itself. Paths remain platform-neutral strings in this contract;
+the future executor is responsible for resolving them against its environment
+and enforcing the requested boundary.
+
+Filesystem access classes are `read`, `create`, `modify`, and `delete`.
+Network protocols are `tcp`, `udp`, `http`, and `https`.
+
+### Parent Binding And Authority
+
+The run ID, Agent Run Request digest, capability, policy identities, and
+resource-budget digest must exactly match a validated `AgentRunRequest`.
+Effect-specific approval references identify evidence. They do not authorize
+execution by themselves.
+
+`RunCoordinator` remains the sole decision authority. The contract validator
+does not recompute policy or reinterpret a decision code.
+
+### Repeatability
+
+The closed repeatability classes are:
+
+- `repeatable`: an identical request is declared safe to repeat;
+- `idempotent`: repetition is expected to converge on the same effect; and
+- `non_repeatable`: automatic retry is unsafe without reconciliation.
+
+These values are declarations for a future runtime. This contract performs no
+retry. In particular, `non_repeatable` and `unknown_outcome` remain separate so
+the runtime cannot turn uncertainty into an ordinary retryable failure.
+
+## Protected Effect Result
+
+The result uses a digest-bearing envelope:
+
+```json
+{
+  "result_digest": "sha256:<64 lowercase hex>",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0"
+  }
+}
+```
+
+The body binds the effect and run identities, both request digests, observed
+pre-effect identities, the decisive `RunCoordinator` decision, execution
+status, optional post-effect subject and process exit, effect-local usage, optional executor
+and sandbox identities, a reason, and typed evidence references.
+
+The decisive decision record contains its ID, gate, exact Protected Effect
+Request digest, observed subject digest, and the existing `Decision`. Full
+multi-gate chronology remains in the Terminal Run Receipt event ledger.
+
+### Decision And Execution Matrix
+
+| Execution status | Required consistency |
+| --- | --- |
+| `executed` | `allow`; exact observed request identities; post-effect subject, executor, sandbox, usage, and subject-observation evidence |
+| `awaiting_authority` | `ask`; non-empty reason; zero usage and no execution-derived fields or evidence |
+| `denied` | `block`; non-empty reason; zero usage and no execution-derived fields or evidence |
+| `failed` | `allow`; known attempted failure with a post-effect subject, executor, sandbox, usage, and failure evidence |
+| `interrupted` | `allow`; known interrupted attempt with a post-effect subject, executor, sandbox, usage, and interruption evidence |
+| `unknown_outcome` | `allow`; dispatched but unreconciled attempt with executor, sandbox, last-known usage, reason, and unknown-outcome evidence; post-effect subject may be absent |
+
+`ask` and `block` never coexist with execution-derived state. Attempted statuses
+require content-addressed executor, sandbox, and usage evidence. Contradictory
+failure, interruption, and unknown-outcome evidence is rejected.
+
+An observation result with a known post-effect subject preserves the subject
+digest. A mutation result with a known post-effect subject requires
+both mutation and artifact evidence even if the resulting digest is unchanged.
+Known `process` execution and failure records contain exactly one exit code or
+signal plus exit evidence.
+
+Process exits are a tagged union:
+
+```json
+{"exit_type":"code","code":0}
+{"exit_type":"signal","signal":"SIGTERM"}
+```
+
+### Drift Denials
+
+Subject or capability-schema drift is evidence that the requested identities
+were no longer current, not evidence that execution occurred. A valid drift
+result therefore uses `denied`, a `block` decision, zero usage, no executor or
+sandbox result, and the requested-versus-observed identities already present
+in the linked request and result.
+
+The precise reason values and required evidence are:
+
+| Drift | Reason | Evidence |
+| --- | --- | --- |
+| Subject only | `protected_effect.stale_subject` | `subject_observation` |
+| Tool schema only | `protected_effect.capability_schema_drift` | `capability_schema` |
+| Both | `protected_effect.subject_and_capability_schema_drift` | both evidence types |
+
+The observed capability identity still matches the request. A subject or
+tool-schema drift mismatch paired with any status other than `denied` fails
+closed.
+
+### Evidence
+
+Effect evidence types are closed to `exit`, `output`, `artifact`, `mutation`,
+`usage`, `executor`, `sandbox`, `failure`, `interruption`,
+`subject_observation`, `capability_schema`, and `unknown_outcome`.
+
+Each reference contains only its type, a SHA-256 digest, and an optional
+locator. There is no raw-output, provider-message, or secret field. These
+effect-specific evidence types do not expand the frozen Agent Run 0.1.0
+evidence vocabulary.
+
+## Canonicalization, Integrity, And Replay
+
+GAAP uses RFC 8785 JSON Canonicalization Scheme bytes and lowercase SHA-256:
+
+```text
+effect_request_digest = SHA-256(JCS(ProtectedEffectRequest))
+result_digest = SHA-256(JCS(ProtectedEffectResultBody))
+```
+
+Result verification checks the envelope digest before validating the body
+against the exact parent Agent Run and Protected Effect Request. Cross-run,
+cross-request, effect identity, sequence, decision digest, subject, capability,
+or sandbox mismatches fail closed. A modified result body returns the distinct
+`result_tampering` error.
+
+The digests provide integrity and content addressing. They do not prove who
+produced the values; signing and producer authenticity are later work.
+
+## Public Rust Interface
+
+The `gaap::contracts::protected_effect` implementation is exposed as one
+contract interface through `gaap::contracts`:
+
+- strict request and result parsing;
+- RFC 8785 request and result-body canonicalization;
+- parent-bound request and result-body validation;
+- result sealing and verification; and
+- generated request and result JSON Schemas.
+
+All operations are pure over caller-supplied values. They perform no protected
+effect and no persistence or network I/O.
+
+## Relationship To Agent Run 0.1.0
+
+Every `protected_effect_digest` in an Agent Run 0.1.0 decision, execution, or
+mutation event is the canonical Protected Effect Request digest defined here.
+The existing Agent Run Rust interfaces, schemas, examples, evidence enum, and
+`RunCoordinator` decisions remain unchanged.
+
+The Terminal Run Receipt remains authoritative for ordered lifecycle and
+multi-gate chronology. The bounded runtime will connect these contracts to that
+ledger in a later phase.
+
+## Reproduce The Artifacts
+
+```bash
+cargo run --locked --example generate-contract-schemas -- --check
+cargo run --locked --example generate-contract-examples -- --check
+cargo run --locked --example generate-protected-effect-examples -- --check
+cargo test --locked --test protected_effect_contracts --test schema_contracts
+```

--- a/examples/contracts/protected-effect/v0.1.0/awaiting-authority.json
+++ b/examples/contracts/protected-effect/v0.1.0/awaiting-authority.json
@@ -1,0 +1,46 @@
+{
+  "result_digest": "sha256:cd99f4ccc4ddd9c06165c9ed91dc0957a2bbb8444c95c850a35c17e42b7dfeca",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "ask",
+        "code": "permission.policy_requires_approval",
+        "effects": []
+      }
+    },
+    "execution_status": "awaiting_authority",
+    "observed_post_effect_subject": null,
+    "exit": null,
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "executor": null,
+    "sandbox_profile": null,
+    "reason": "permission.policy_requires_approval",
+    "evidence": []
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/completed.json
+++ b/examples/contracts/protected-effect/v0.1.0/completed.json
@@ -1,0 +1,102 @@
+{
+  "result_digest": "sha256:23f356189b3ecaf152d3cb419cc15b9d7f690f00b1ac936668ea97da39e6f9e8",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "allow",
+        "code": "permission.policy_allowed",
+        "effects": []
+      }
+    },
+    "execution_status": "executed",
+    "observed_post_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+    },
+    "exit": {
+      "exit_type": "code",
+      "code": 0
+    },
+    "usage": {
+      "cost_micros": 200000,
+      "elapsed_ms": 2000,
+      "model_tokens": 0,
+      "tool_calls": 1
+    },
+    "executor": {
+      "name": "local-runner",
+      "version": "0.1.0",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    "sandbox_profile": {
+      "name": "local-process",
+      "version": "0.1.0",
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "reason": null,
+    "evidence": [
+      {
+        "evidence_type": "usage",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": null
+      },
+      {
+        "evidence_type": "executor",
+        "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "locator": null
+      },
+      {
+        "evidence_type": "sandbox",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "locator": null
+      },
+      {
+        "evidence_type": "exit",
+        "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "locator": null
+      },
+      {
+        "evidence_type": "output",
+        "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "locator": null
+      },
+      {
+        "evidence_type": "artifact",
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": null
+      },
+      {
+        "evidence_type": "mutation",
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": null
+      },
+      {
+        "evidence_type": "subject_observation",
+        "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "locator": null
+      }
+    ]
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/denied.json
+++ b/examples/contracts/protected-effect/v0.1.0/denied.json
@@ -1,0 +1,46 @@
+{
+  "result_digest": "sha256:fbcbf2e77af588fe5ba86578e8188e8870055be7aeffb5e0e651e372aa92dd8c",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "block",
+        "code": "permission.denied",
+        "effects": []
+      }
+    },
+    "execution_status": "denied",
+    "observed_post_effect_subject": null,
+    "exit": null,
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "executor": null,
+    "sandbox_profile": null,
+    "reason": "permission.denied",
+    "evidence": []
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/failed.json
+++ b/examples/contracts/protected-effect/v0.1.0/failed.json
@@ -1,0 +1,107 @@
+{
+  "result_digest": "sha256:bd1d97fdbb2e8bb60dda7262d0ba9434826162bc3dc458f58591c40427715844",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "allow",
+        "code": "permission.policy_allowed",
+        "effects": []
+      }
+    },
+    "execution_status": "failed",
+    "observed_post_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+    },
+    "exit": {
+      "exit_type": "code",
+      "code": 1
+    },
+    "usage": {
+      "cost_micros": 200000,
+      "elapsed_ms": 2000,
+      "model_tokens": 0,
+      "tool_calls": 1
+    },
+    "executor": {
+      "name": "local-runner",
+      "version": "0.1.0",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    "sandbox_profile": {
+      "name": "local-process",
+      "version": "0.1.0",
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "reason": "process exited unsuccessfully",
+    "evidence": [
+      {
+        "evidence_type": "usage",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": null
+      },
+      {
+        "evidence_type": "executor",
+        "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "locator": null
+      },
+      {
+        "evidence_type": "sandbox",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "locator": null
+      },
+      {
+        "evidence_type": "exit",
+        "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "locator": null
+      },
+      {
+        "evidence_type": "output",
+        "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "locator": null
+      },
+      {
+        "evidence_type": "artifact",
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": null
+      },
+      {
+        "evidence_type": "mutation",
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": null
+      },
+      {
+        "evidence_type": "failure",
+        "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "locator": null
+      },
+      {
+        "evidence_type": "subject_observation",
+        "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "locator": null
+      }
+    ]
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/interrupted.json
+++ b/examples/contracts/protected-effect/v0.1.0/interrupted.json
@@ -1,0 +1,102 @@
+{
+  "result_digest": "sha256:7c4d1f9f7396bfc5f74836b6f36775707e5621a12aaae2929e32f1c528e699d1",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "allow",
+        "code": "permission.policy_allowed",
+        "effects": []
+      }
+    },
+    "execution_status": "interrupted",
+    "observed_post_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+    },
+    "exit": {
+      "exit_type": "signal",
+      "signal": "SIGTERM"
+    },
+    "usage": {
+      "cost_micros": 200000,
+      "elapsed_ms": 2000,
+      "model_tokens": 0,
+      "tool_calls": 1
+    },
+    "executor": {
+      "name": "local-runner",
+      "version": "0.1.0",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    "sandbox_profile": {
+      "name": "local-process",
+      "version": "0.1.0",
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "reason": "operator interrupted the process",
+    "evidence": [
+      {
+        "evidence_type": "usage",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": null
+      },
+      {
+        "evidence_type": "executor",
+        "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "locator": null
+      },
+      {
+        "evidence_type": "sandbox",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "locator": null
+      },
+      {
+        "evidence_type": "exit",
+        "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "locator": null
+      },
+      {
+        "evidence_type": "artifact",
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "locator": null
+      },
+      {
+        "evidence_type": "mutation",
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "locator": null
+      },
+      {
+        "evidence_type": "interruption",
+        "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "locator": null
+      },
+      {
+        "evidence_type": "subject_observation",
+        "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "locator": null
+      }
+    ]
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/protected-effect-request.json
+++ b/examples/contracts/protected-effect/v0.1.0/protected-effect-request.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "gaap.protected-effect-request/0.1.0",
+  "effect_id": "effect-001",
+  "effect_sequence": 1,
+  "run_id": "run-001",
+  "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+  "subject": {
+    "kind": "repository",
+    "locator": "https://example.invalid/repository",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "operation_family": "process",
+  "normalized_operation": "process.spawn",
+  "capability": {
+    "name": "change-code",
+    "version": "1",
+    "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "input_digest": "sha256:c91d43be9e251857fba61b44e0832c48e77eb0ba8f1084fdcdaab2dab799316c",
+  "input_metadata": [
+    {
+      "name": "argument_count",
+      "value": "2"
+    },
+    {
+      "name": "content_type",
+      "value": "application/json"
+    }
+  ],
+  "requested_scopes": [
+    {
+      "scope_type": "process",
+      "executable": "/usr/bin/cargo",
+      "working_directory": "/workspace"
+    },
+    {
+      "scope_type": "filesystem",
+      "root": "/workspace",
+      "access": [
+        "read",
+        "modify"
+      ],
+      "recursive": true
+    },
+    {
+      "scope_type": "network",
+      "protocol": "https",
+      "host": "crates.io",
+      "port": 443
+    },
+    {
+      "scope_type": "external_service",
+      "service": "github",
+      "operation": "pull_request.comment",
+      "resource": "nnennandukwe/governed-agent-autonomy-patterns#22"
+    }
+  ],
+  "policies": [
+    {
+      "name": "gaap.run-coordinator",
+      "version": "0.1.0",
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "approval_context": [
+    {
+      "approval_id": "approval-effect-001",
+      "actor_id": "maintainer-001",
+      "scope": "protected_effect",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "evidence": {
+        "evidence_type": "approval",
+        "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "locator": null
+      }
+    }
+  ],
+  "resource_budget_digest": "sha256:8f9d506cc02d9cb1de0f85bdf6ab2e4748ffb529e35ab4b9855b5bc42c8e8da8",
+  "sandbox_profile": {
+    "name": "local-process",
+    "version": "0.1.0",
+    "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "idempotency_key": "run-001/effect-001",
+  "repeatability": "non_repeatable",
+  "expected_effect_class": "mutation"
+}

--- a/examples/contracts/protected-effect/v0.1.0/schema-drift.json
+++ b/examples/contracts/protected-effect/v0.1.0/schema-drift.json
@@ -1,0 +1,52 @@
+{
+  "result_digest": "sha256:9ee0f1864e08e4bf318db39a847ec8e5f7bf835c408d6bec27c2bfcddc1b92df",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "block",
+        "code": "permission.denied",
+        "effects": []
+      }
+    },
+    "execution_status": "denied",
+    "observed_post_effect_subject": null,
+    "exit": null,
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "executor": null,
+    "sandbox_profile": null,
+    "reason": "protected_effect.capability_schema_drift",
+    "evidence": [
+      {
+        "evidence_type": "capability_schema",
+        "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "locator": null
+      }
+    ]
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/stale-subject.json
+++ b/examples/contracts/protected-effect/v0.1.0/stale-subject.json
@@ -1,0 +1,52 @@
+{
+  "result_digest": "sha256:76bc16288ae01e5e37719481fad241beb2e26513ac0a12e8eaee405ed0e77f0b",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+      "decision": {
+        "outcome": "block",
+        "code": "permission.denied",
+        "effects": []
+      }
+    },
+    "execution_status": "denied",
+    "observed_post_effect_subject": null,
+    "exit": null,
+    "usage": {
+      "cost_micros": 0,
+      "elapsed_ms": 0,
+      "model_tokens": 0,
+      "tool_calls": 0
+    },
+    "executor": null,
+    "sandbox_profile": null,
+    "reason": "protected_effect.stale_subject",
+    "evidence": [
+      {
+        "evidence_type": "subject_observation",
+        "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "locator": null
+      }
+    ]
+  }
+}

--- a/examples/contracts/protected-effect/v0.1.0/unknown-outcome.json
+++ b/examples/contracts/protected-effect/v0.1.0/unknown-outcome.json
@@ -1,0 +1,75 @@
+{
+  "result_digest": "sha256:3d7a8895c20b531261a2ed3016559bf1ab9cf48753a06ecf567c870fab749354",
+  "body": {
+    "schema_version": "gaap.protected-effect-result/0.1.0",
+    "effect_id": "effect-001",
+    "effect_sequence": 1,
+    "run_id": "run-001",
+    "agent_run_request_digest": "sha256:3f21b4e9c8f22cd93e6d403efe2f9e35881ae46c0aa0b400c91b03727f5e7e89",
+    "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+    "observed_pre_effect_subject": {
+      "kind": "repository",
+      "locator": "https://example.invalid/repository",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "observed_capability": {
+      "name": "change-code",
+      "version": "1",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "observed_tool_schema_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "decision": {
+      "decision_id": "decision-001",
+      "gate": "permission",
+      "effect_request_digest": "sha256:e063f78cbd0cd7eae9dba827ddc6740e0e0fd4ee8d3da2ca9f13841fe31970b5",
+      "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decision": {
+        "outcome": "allow",
+        "code": "permission.policy_allowed",
+        "effects": []
+      }
+    },
+    "execution_status": "unknown_outcome",
+    "observed_post_effect_subject": null,
+    "exit": null,
+    "usage": {
+      "cost_micros": 200000,
+      "elapsed_ms": 2000,
+      "model_tokens": 0,
+      "tool_calls": 1
+    },
+    "executor": {
+      "name": "local-runner",
+      "version": "0.1.0",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    "sandbox_profile": {
+      "name": "local-process",
+      "version": "0.1.0",
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "reason": "executor disconnected before reconciliation",
+    "evidence": [
+      {
+        "evidence_type": "usage",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "locator": null
+      },
+      {
+        "evidence_type": "executor",
+        "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "locator": null
+      },
+      {
+        "evidence_type": "sandbox",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "locator": null
+      },
+      {
+        "evidence_type": "unknown_outcome",
+        "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+        "locator": null
+      }
+    ]
+  }
+}

--- a/examples/generate-contract-schemas.rs
+++ b/examples/generate-contract-schemas.rs
@@ -3,10 +3,17 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use gaap::contracts::{agent_run_request_schema, terminal_run_receipt_schema};
+use gaap::contracts::{
+    agent_run_request_schema, protected_effect_request_schema, protected_effect_result_schema,
+    terminal_run_receipt_schema,
+};
 
 const REQUEST_PATH: &str = "schemas/agent-run/v0.1.0/agent-run-request.schema.json";
 const RECEIPT_PATH: &str = "schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json";
+const EFFECT_REQUEST_PATH: &str =
+    "schemas/protected-effect/v0.1.0/protected-effect-request.schema.json";
+const EFFECT_RESULT_PATH: &str =
+    "schemas/protected-effect/v0.1.0/protected-effect-result.schema.json";
 
 fn main() -> ExitCode {
     match run() {
@@ -34,6 +41,8 @@ fn run() -> Result<(), String> {
     let schemas = [
         (REQUEST_PATH, agent_run_request_schema()),
         (RECEIPT_PATH, terminal_run_receipt_schema()),
+        (EFFECT_REQUEST_PATH, protected_effect_request_schema()),
+        (EFFECT_RESULT_PATH, protected_effect_result_schema()),
     ];
     for (relative_path, schema) in schemas {
         let path = root.join(relative_path);

--- a/examples/generate-protected-effect-examples.rs
+++ b/examples/generate-protected-effect-examples.rs
@@ -1,0 +1,512 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use gaap::contracts::{
+    AgentRunRequest, ApprovalReference, ContractSupport, EffectClass, EffectEvidenceReference,
+    EffectEvidenceType, EffectExecutionStatus, EffectExit, EffectUsage, EvidenceReference,
+    EvidenceType, ExecutorIdentity, FilesystemAccess, InputMetadataEntry, NetworkProtocol,
+    OperationFamily, PROTECTED_EFFECT_REQUEST_SCHEMA, PROTECTED_EFFECT_RESULT_SCHEMA,
+    ProtectedEffectDecision, ProtectedEffectRequest, ProtectedEffectResult,
+    ProtectedEffectResultBody, Repeatability, RequestedScope, SandboxProfileIdentity,
+    canonical_resource_budget_digest, parse_agent_run_request_json, seal_protected_effect_result,
+    validate_protected_effect_request, verify_protected_effect_result,
+};
+use gaap::{Decision, Gate, Outcome};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const AGENT_RUN_REQUEST_PATH: &str = "examples/contracts/v0.1.0/agent-run-request.json";
+const DIRECTORY: &str = "examples/contracts/protected-effect/v0.1.0";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("protected effect example generation failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let arguments: Vec<String> = env::args().skip(1).collect();
+    let check = match arguments.as_slice() {
+        [] => false,
+        [argument] if argument == "--check" => true,
+        _ => {
+            return Err(
+                "usage: cargo run --locked --example generate-protected-effect-examples -- [--check]"
+                    .to_owned(),
+            );
+        }
+    };
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let agent_run_request = read_agent_run_request(&root)?;
+    let support = ContractSupport::new(agent_run_request.policies.clone());
+    let request = protected_effect_request(&agent_run_request)?;
+    let request_digest = validate_protected_effect_request(&agent_run_request, &support, &request)
+        .map_err(|error| error.to_string())?;
+    let results = [
+        (
+            "completed.json",
+            completed(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "denied.json",
+            denied(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "awaiting-authority.json",
+            awaiting_authority(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "failed.json",
+            failed(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "interrupted.json",
+            interrupted(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "stale-subject.json",
+            stale_subject(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "schema-drift.json",
+            schema_drift(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+        (
+            "unknown-outcome.json",
+            unknown_outcome(&agent_run_request, &support, &request, &request_digest)?,
+        ),
+    ];
+
+    materialize(&root, "protected-effect-request.json", &request, check)?;
+    for (file_name, result) in results {
+        verify_protected_effect_result(&agent_run_request, &support, &request, &result)
+            .map_err(|error| format!("{file_name} does not verify: {error}"))?;
+        materialize(&root, file_name, &result, check)?;
+    }
+    Ok(())
+}
+
+fn read_agent_run_request(root: &Path) -> Result<AgentRunRequest, String> {
+    let bytes = fs::read(root.join(AGENT_RUN_REQUEST_PATH))
+        .map_err(|error| format!("could not read {AGENT_RUN_REQUEST_PATH}: {error}"))?;
+    parse_agent_run_request_json(&bytes)
+        .map_err(|error| format!("{AGENT_RUN_REQUEST_PATH} is invalid: {error}"))
+}
+
+fn protected_effect_request(
+    agent_run_request: &AgentRunRequest,
+) -> Result<ProtectedEffectRequest, String> {
+    let agent_run_request_digest = gaap::contracts::validate_request(
+        agent_run_request,
+        &ContractSupport::new(agent_run_request.policies.clone()),
+    )
+    .map_err(|error| error.to_string())?;
+    let resource_budget_digest =
+        canonical_resource_budget_digest(&agent_run_request.resource_budget)
+            .map_err(|error| error.to_string())?;
+    let normalized_input = serde_json::json!({
+        "arguments": ["test", "--locked"],
+        "executable": "/usr/bin/cargo"
+    });
+    let input_bytes = serde_jcs::to_vec(&normalized_input).map_err(|error| error.to_string())?;
+
+    Ok(ProtectedEffectRequest {
+        schema_version: PROTECTED_EFFECT_REQUEST_SCHEMA.to_owned(),
+        effect_id: "effect-001".to_owned(),
+        effect_sequence: 1,
+        run_id: agent_run_request.run_id.clone(),
+        agent_run_request_digest,
+        subject: agent_run_request.subject.clone(),
+        operation_family: OperationFamily::Process,
+        normalized_operation: "process.spawn".to_owned(),
+        capability: agent_run_request.requested_capability.clone(),
+        tool_schema_digest: Some(digest('d')),
+        input_digest: format!("sha256:{:x}", Sha256::digest(input_bytes)),
+        input_metadata: vec![
+            InputMetadataEntry {
+                name: "argument_count".to_owned(),
+                value: "2".to_owned(),
+            },
+            InputMetadataEntry {
+                name: "content_type".to_owned(),
+                value: "application/json".to_owned(),
+            },
+        ],
+        requested_scopes: vec![
+            RequestedScope::Process {
+                executable: "/usr/bin/cargo".to_owned(),
+                working_directory: "/workspace".to_owned(),
+            },
+            RequestedScope::Filesystem {
+                root: "/workspace".to_owned(),
+                access: vec![FilesystemAccess::Read, FilesystemAccess::Modify],
+                recursive: true,
+            },
+            RequestedScope::Network {
+                protocol: NetworkProtocol::Https,
+                host: "crates.io".to_owned(),
+                port: 443,
+            },
+            RequestedScope::ExternalService {
+                service: "github".to_owned(),
+                operation: "pull_request.comment".to_owned(),
+                resource: "nnennandukwe/governed-agent-autonomy-patterns#22".to_owned(),
+            },
+        ],
+        policies: agent_run_request.policies.clone(),
+        approval_context: vec![ApprovalReference {
+            approval_id: "approval-effect-001".to_owned(),
+            actor_id: "maintainer-001".to_owned(),
+            scope: "protected_effect".to_owned(),
+            subject_digest: agent_run_request.subject.digest.clone(),
+            evidence: EvidenceReference {
+                evidence_type: EvidenceType::Approval,
+                digest: digest('e'),
+                locator: None,
+            },
+        }],
+        resource_budget_digest,
+        sandbox_profile: SandboxProfileIdentity {
+            name: "local-process".to_owned(),
+            version: "0.1.0".to_owned(),
+            digest: digest('f'),
+        },
+        idempotency_key: "run-001/effect-001".to_owned(),
+        repeatability: Repeatability::NonRepeatable,
+        expected_effect_class: EffectClass::Mutation,
+    })
+}
+
+fn completed(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    let mut body = attempted_body(
+        request,
+        request_digest,
+        EffectExecutionStatus::Executed,
+        None,
+    );
+    body.exit = Some(EffectExit::Code { code: 0 });
+    body.evidence.extend([
+        evidence(EffectEvidenceType::Exit, '0'),
+        evidence(EffectEvidenceType::Output, '1'),
+        evidence(EffectEvidenceType::Artifact, '2'),
+        evidence(EffectEvidenceType::Mutation, '3'),
+        evidence(EffectEvidenceType::SubjectObservation, '7'),
+    ]);
+    seal(agent_run_request, support, request, body)
+}
+
+fn denied(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    seal(
+        agent_run_request,
+        support,
+        request,
+        non_execution_body(
+            request,
+            request_digest,
+            EffectExecutionStatus::Denied,
+            Outcome::Block,
+            "permission.denied",
+        ),
+    )
+}
+
+fn awaiting_authority(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    seal(
+        agent_run_request,
+        support,
+        request,
+        non_execution_body(
+            request,
+            request_digest,
+            EffectExecutionStatus::AwaitingAuthority,
+            Outcome::Ask,
+            "permission.policy_requires_approval",
+        ),
+    )
+}
+
+fn failed(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    let mut body = attempted_body(
+        request,
+        request_digest,
+        EffectExecutionStatus::Failed,
+        Some("process exited unsuccessfully"),
+    );
+    body.exit = Some(EffectExit::Code { code: 1 });
+    body.evidence.extend([
+        evidence(EffectEvidenceType::Exit, '0'),
+        evidence(EffectEvidenceType::Output, '1'),
+        evidence(EffectEvidenceType::Artifact, '2'),
+        evidence(EffectEvidenceType::Mutation, '3'),
+        evidence(EffectEvidenceType::Failure, '8'),
+        evidence(EffectEvidenceType::SubjectObservation, '7'),
+    ]);
+    seal(agent_run_request, support, request, body)
+}
+
+fn interrupted(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    let mut body = attempted_body(
+        request,
+        request_digest,
+        EffectExecutionStatus::Interrupted,
+        Some("operator interrupted the process"),
+    );
+    body.exit = Some(EffectExit::Signal {
+        signal: "SIGTERM".to_owned(),
+    });
+    body.evidence.extend([
+        evidence(EffectEvidenceType::Exit, '0'),
+        evidence(EffectEvidenceType::Artifact, '2'),
+        evidence(EffectEvidenceType::Mutation, '3'),
+        evidence(EffectEvidenceType::Interruption, '8'),
+        evidence(EffectEvidenceType::SubjectObservation, '7'),
+    ]);
+    seal(agent_run_request, support, request, body)
+}
+
+fn stale_subject(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    let mut body = non_execution_body(
+        request,
+        request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+        "protected_effect.stale_subject",
+    );
+    body.observed_pre_effect_subject.digest = digest('8');
+    body.decision.subject_digest = digest('8');
+    body.evidence = vec![evidence(EffectEvidenceType::SubjectObservation, '8')];
+    seal(agent_run_request, support, request, body)
+}
+
+fn schema_drift(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    let mut body = non_execution_body(
+        request,
+        request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+        "protected_effect.capability_schema_drift",
+    );
+    body.observed_tool_schema_digest = Some(digest('8'));
+    body.evidence = vec![evidence(EffectEvidenceType::CapabilitySchema, '8')];
+    seal(agent_run_request, support, request, body)
+}
+
+fn unknown_outcome(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+) -> Result<ProtectedEffectResult, String> {
+    let body = attempted_body(
+        request,
+        request_digest,
+        EffectExecutionStatus::UnknownOutcome,
+        Some("executor disconnected before reconciliation"),
+    );
+    seal(agent_run_request, support, request, body)
+}
+
+fn attempted_body(
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+    status: EffectExecutionStatus,
+    reason: Option<&str>,
+) -> ProtectedEffectResultBody {
+    let mut post_subject = request.subject.clone();
+    post_subject.digest = digest('9');
+    let unknown = status == EffectExecutionStatus::UnknownOutcome;
+    let mut evidence_refs = vec![
+        evidence(EffectEvidenceType::Usage, '4'),
+        evidence(EffectEvidenceType::Executor, '5'),
+        evidence(EffectEvidenceType::Sandbox, '6'),
+    ];
+    if unknown {
+        evidence_refs.push(evidence(EffectEvidenceType::UnknownOutcome, '8'));
+    }
+
+    ProtectedEffectResultBody {
+        schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+        effect_id: request.effect_id.clone(),
+        effect_sequence: request.effect_sequence,
+        run_id: request.run_id.clone(),
+        agent_run_request_digest: request.agent_run_request_digest.clone(),
+        effect_request_digest: request_digest.to_owned(),
+        observed_pre_effect_subject: request.subject.clone(),
+        observed_capability: request.capability.clone(),
+        observed_tool_schema_digest: request.tool_schema_digest.clone(),
+        decision: decision(Outcome::Allow, request_digest, &request.subject.digest),
+        execution_status: status,
+        observed_post_effect_subject: (!unknown).then_some(post_subject),
+        exit: None,
+        usage: EffectUsage {
+            cost_micros: 200_000,
+            elapsed_ms: 2_000,
+            model_tokens: 0,
+            tool_calls: 1,
+        },
+        executor: Some(ExecutorIdentity {
+            name: "local-runner".to_owned(),
+            version: "0.1.0".to_owned(),
+            digest: digest('6'),
+        }),
+        sandbox_profile: Some(request.sandbox_profile.clone()),
+        reason: reason.map(str::to_owned),
+        evidence: evidence_refs,
+    }
+}
+
+fn non_execution_body(
+    request: &ProtectedEffectRequest,
+    request_digest: &str,
+    status: EffectExecutionStatus,
+    outcome: Outcome,
+    reason: &str,
+) -> ProtectedEffectResultBody {
+    ProtectedEffectResultBody {
+        schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+        effect_id: request.effect_id.clone(),
+        effect_sequence: request.effect_sequence,
+        run_id: request.run_id.clone(),
+        agent_run_request_digest: request.agent_run_request_digest.clone(),
+        effect_request_digest: request_digest.to_owned(),
+        observed_pre_effect_subject: request.subject.clone(),
+        observed_capability: request.capability.clone(),
+        observed_tool_schema_digest: request.tool_schema_digest.clone(),
+        decision: decision(outcome, request_digest, &request.subject.digest),
+        execution_status: status,
+        observed_post_effect_subject: None,
+        exit: None,
+        usage: EffectUsage {
+            cost_micros: 0,
+            elapsed_ms: 0,
+            model_tokens: 0,
+            tool_calls: 0,
+        },
+        executor: None,
+        sandbox_profile: None,
+        reason: Some(reason.to_owned()),
+        evidence: vec![],
+    }
+}
+
+fn decision(
+    outcome: Outcome,
+    request_digest: &str,
+    subject_digest: &str,
+) -> ProtectedEffectDecision {
+    let code = match outcome {
+        Outcome::Allow => "permission.policy_allowed",
+        Outcome::Ask => "permission.policy_requires_approval",
+        Outcome::Block => "permission.denied",
+    };
+    ProtectedEffectDecision {
+        decision_id: "decision-001".to_owned(),
+        gate: Gate::Permission,
+        effect_request_digest: request_digest.to_owned(),
+        subject_digest: subject_digest.to_owned(),
+        decision: Decision {
+            outcome,
+            code: code.to_owned(),
+            effects: vec![],
+        },
+    }
+}
+
+fn evidence(evidence_type: EffectEvidenceType, byte: char) -> EffectEvidenceReference {
+    EffectEvidenceReference {
+        evidence_type,
+        digest: digest(byte),
+        locator: None,
+    }
+}
+
+fn seal(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    body: ProtectedEffectResultBody,
+) -> Result<ProtectedEffectResult, String> {
+    seal_protected_effect_result(agent_run_request, support, request, body)
+        .map_err(|error| error.to_string())
+}
+
+fn materialize<T: Serialize>(
+    root: &Path,
+    file_name: &str,
+    value: &T,
+    check: bool,
+) -> Result<(), String> {
+    let relative_path = format!("{DIRECTORY}/{file_name}");
+    let path = root.join(&relative_path);
+    let contents = format!(
+        "{}\n",
+        serde_json::to_string_pretty(value)
+            .map_err(|error| format!("could not serialize {relative_path}: {error}"))?
+    );
+    if check {
+        let actual = fs::read_to_string(&path)
+            .map_err(|error| format!("could not read {relative_path}: {error}"))?;
+        if actual != contents {
+            return Err(format!(
+                "{relative_path} is stale; run `cargo run --locked --example generate-protected-effect-examples`"
+            ));
+        }
+        println!("example is current: {relative_path}");
+    } else {
+        let parent = path
+            .parent()
+            .ok_or_else(|| format!("example path has no parent: {relative_path}"))?;
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+        fs::write(&path, contents)
+            .map_err(|error| format!("could not write {relative_path}: {error}"))?;
+        println!("wrote example: {relative_path}");
+    }
+    Ok(())
+}
+
+fn digest(byte: char) -> String {
+    format!("sha256:{}", byte.to_string().repeat(64))
+}

--- a/schemas/protected-effect/v0.1.0/protected-effect-request.schema.json
+++ b/schemas/protected-effect/v0.1.0/protected-effect-request.schema.json
@@ -1,0 +1,479 @@
+{
+  "$defs": {
+    "ApprovalReference": {
+      "additionalProperties": false,
+      "description": "Existing approval evidence bound to an actor, scope, and exact subject.",
+      "properties": {
+        "actor_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "approval_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/EvidenceReference"
+        },
+        "scope": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "subject_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "approval_id",
+        "actor_id",
+        "scope",
+        "subject_digest",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "CapabilityIdentity": {
+      "additionalProperties": false,
+      "description": "Requested engineering capability bound to its versioned content digest.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "EffectClass": {
+      "description": "Whether the proposed effect is expected to observe or mutate its subject.",
+      "enum": [
+        "observation",
+        "mutation"
+      ],
+      "type": "string"
+    },
+    "EvidenceReference": {
+      "additionalProperties": false,
+      "description": "Content-addressed evidence metadata; raw evidence remains external.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "evidence_type": {
+          "$ref": "#/$defs/EvidenceType"
+        },
+        "locator": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "evidence_type",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "EvidenceType": {
+      "description": "Closed evidence categories supported by contract version 0.1.0.",
+      "enum": [
+        "approval",
+        "command_output",
+        "artifact",
+        "tool_execution",
+        "verification_attestation",
+        "resource_usage",
+        "interruption"
+      ],
+      "type": "string"
+    },
+    "FilesystemAccess": {
+      "description": "Filesystem authority classes supported by the typed scope contract.",
+      "enum": [
+        "read",
+        "create",
+        "modify",
+        "delete"
+      ],
+      "type": "string"
+    },
+    "InputMetadataEntry": {
+      "additionalProperties": false,
+      "description": "Bounded non-secret metadata describing external normalized input.",
+      "properties": {
+        "name": {
+          "maxLength": 64,
+          "minLength": 1,
+          "type": "string"
+        },
+        "value": {
+          "maxLength": 256,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "NetworkProtocol": {
+      "description": "Network protocols supported by the typed scope contract.",
+      "enum": [
+        "tcp",
+        "udp",
+        "http",
+        "https"
+      ],
+      "type": "string"
+    },
+    "OperationFamily": {
+      "description": "Closed operation families supported by Protected Effect Request 0.1.0.",
+      "enum": [
+        "filesystem",
+        "process",
+        "network",
+        "external_service"
+      ],
+      "type": "string"
+    },
+    "PolicyIdentity": {
+      "additionalProperties": false,
+      "description": "Exact policy identity accepted by a caller's [`super::ContractSupport`].",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "Repeatability": {
+      "description": "How the future runtime may reason about repeating an identical request.",
+      "enum": [
+        "repeatable",
+        "idempotent",
+        "non_repeatable"
+      ],
+      "type": "string"
+    },
+    "RequestedScope": {
+      "description": "One exact resource boundary requested by a protected effect.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "access": {
+              "items": {
+                "$ref": "#/$defs/FilesystemAccess"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "recursive": {
+              "type": "boolean"
+            },
+            "root": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "scope_type": {
+              "const": "filesystem",
+              "type": "string"
+            }
+          },
+          "required": [
+            "scope_type",
+            "root",
+            "access",
+            "recursive"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "executable": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "scope_type": {
+              "const": "process",
+              "type": "string"
+            },
+            "working_directory": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "scope_type",
+            "executable",
+            "working_directory"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "host": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "port": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "protocol": {
+              "$ref": "#/$defs/NetworkProtocol"
+            },
+            "scope_type": {
+              "const": "network",
+              "type": "string"
+            }
+          },
+          "required": [
+            "scope_type",
+            "protocol",
+            "host",
+            "port"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "operation": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "resource": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "scope_type": {
+              "const": "external_service",
+              "type": "string"
+            },
+            "service": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "scope_type",
+            "service",
+            "operation",
+            "resource"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SandboxProfileIdentity": {
+      "additionalProperties": false,
+      "description": "Exact sandbox profile requested for any eventual execution.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "Subject": {
+      "additionalProperties": false,
+      "description": "Exact repository or artifact that the Agent Run may inspect or change.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/SubjectKind"
+        },
+        "locator": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "locator",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "SubjectKind": {
+      "description": "Closed subject categories supported by contract version 0.1.0.",
+      "enum": [
+        "repository",
+        "artifact"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/protected-effect/v0.1.0/protected-effect-request.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One protected effect proposed inside a governed Agent Run.",
+  "properties": {
+    "agent_run_request_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "approval_context": {
+      "items": {
+        "$ref": "#/$defs/ApprovalReference"
+      },
+      "type": "array"
+    },
+    "capability": {
+      "$ref": "#/$defs/CapabilityIdentity"
+    },
+    "effect_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "effect_sequence": {
+      "format": "uint64",
+      "maximum": 9007199254740991,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "expected_effect_class": {
+      "$ref": "#/$defs/EffectClass"
+    },
+    "idempotency_key": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "input_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "input_metadata": {
+      "items": {
+        "$ref": "#/$defs/InputMetadataEntry"
+      },
+      "maxItems": 32,
+      "type": "array"
+    },
+    "normalized_operation": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "operation_family": {
+      "$ref": "#/$defs/OperationFamily"
+    },
+    "policies": {
+      "items": {
+        "$ref": "#/$defs/PolicyIdentity"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "repeatability": {
+      "$ref": "#/$defs/Repeatability"
+    },
+    "requested_scopes": {
+      "items": {
+        "$ref": "#/$defs/RequestedScope"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "resource_budget_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "run_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "sandbox_profile": {
+      "$ref": "#/$defs/SandboxProfileIdentity"
+    },
+    "schema_version": {
+      "const": "gaap.protected-effect-request/0.1.0",
+      "type": "string"
+    },
+    "subject": {
+      "$ref": "#/$defs/Subject"
+    },
+    "tool_schema_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "effect_id",
+    "effect_sequence",
+    "run_id",
+    "agent_run_request_digest",
+    "subject",
+    "operation_family",
+    "normalized_operation",
+    "capability",
+    "input_digest",
+    "input_metadata",
+    "requested_scopes",
+    "policies",
+    "approval_context",
+    "resource_budget_digest",
+    "sandbox_profile",
+    "idempotency_key",
+    "repeatability",
+    "expected_effect_class"
+  ],
+  "title": "GAAP Protected Effect Request 0.1.0",
+  "type": "object"
+}

--- a/schemas/protected-effect/v0.1.0/protected-effect-result.schema.json
+++ b/schemas/protected-effect/v0.1.0/protected-effect-result.schema.json
@@ -1,0 +1,490 @@
+{
+  "$defs": {
+    "CapabilityIdentity": {
+      "additionalProperties": false,
+      "description": "Requested engineering capability bound to its versioned content digest.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "Decision": {
+      "additionalProperties": false,
+      "description": "A normalized decision returned at a protected agent-run effect.",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "effects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "outcome": {
+          "$ref": "#/$defs/Outcome"
+        }
+      },
+      "required": [
+        "outcome",
+        "code",
+        "effects"
+      ],
+      "type": "object"
+    },
+    "EffectEvidenceReference": {
+      "additionalProperties": false,
+      "description": "Content-addressed effect evidence metadata; raw evidence remains external.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "evidence_type": {
+          "$ref": "#/$defs/EffectEvidenceType"
+        },
+        "locator": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "evidence_type",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "EffectEvidenceType": {
+      "description": "Closed evidence categories supported by Protected Effect Result 0.1.0.",
+      "enum": [
+        "exit",
+        "output",
+        "artifact",
+        "mutation",
+        "usage",
+        "executor",
+        "sandbox",
+        "failure",
+        "interruption",
+        "subject_observation",
+        "capability_schema",
+        "unknown_outcome"
+      ],
+      "type": "string"
+    },
+    "EffectExecutionStatus": {
+      "description": "Closed execution outcomes supported by Protected Effect Result 0.1.0.",
+      "enum": [
+        "executed",
+        "awaiting_authority",
+        "denied",
+        "failed",
+        "interrupted",
+        "unknown_outcome"
+      ],
+      "type": "string"
+    },
+    "EffectExit": {
+      "description": "A known process exit, represented without provider-specific status types.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "exit_type": {
+              "const": "code",
+              "type": "string"
+            }
+          },
+          "required": [
+            "exit_type",
+            "code"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "exit_type": {
+              "const": "signal",
+              "type": "string"
+            },
+            "signal": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "exit_type",
+            "signal"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "EffectUsage": {
+      "additionalProperties": false,
+      "description": "Resource usage attributable only to this protected effect attempt.",
+      "properties": {
+        "cost_micros": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "elapsed_ms": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "model_tokens": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tool_calls": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cost_micros",
+        "elapsed_ms",
+        "model_tokens",
+        "tool_calls"
+      ],
+      "type": "object"
+    },
+    "ExecutorIdentity": {
+      "additionalProperties": false,
+      "description": "Exact executor identity observed for an attempted protected effect.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "Gate": {
+      "description": "A deterministic decision point owned by the run coordinator.",
+      "oneOf": [
+        {
+          "const": "plan",
+          "description": "Approval for the exact current plan before mutation.",
+          "type": "string"
+        },
+        {
+          "const": "permission",
+          "description": "Authority for a normalized action before execution.",
+          "type": "string"
+        },
+        {
+          "const": "tool_trust",
+          "description": "Approval for the exact capability before activation.",
+          "type": "string"
+        },
+        {
+          "const": "verification",
+          "description": "Independent evidence for the current subject before completion.",
+          "type": "string"
+        },
+        {
+          "const": "runtime",
+          "description": "Known usage and budget authority before budgeted execution.",
+          "type": "string"
+        },
+        {
+          "const": "workflow",
+          "description": "Aggregate authorization at mutation and completion transitions.",
+          "type": "string"
+        }
+      ]
+    },
+    "Outcome": {
+      "description": "The precedence-bearing result of an integrity decision.",
+      "oneOf": [
+        {
+          "const": "allow",
+          "description": "The protected effect may proceed.",
+          "type": "string"
+        },
+        {
+          "const": "ask",
+          "description": "The protected effect requires new authority before it may proceed.",
+          "type": "string"
+        },
+        {
+          "const": "block",
+          "description": "The protected effect must not proceed.",
+          "type": "string"
+        }
+      ]
+    },
+    "ProtectedEffectDecision": {
+      "additionalProperties": false,
+      "description": "The decisive RunCoordinator record bound to an exact effect request and subject.",
+      "properties": {
+        "decision": {
+          "$ref": "#/$defs/Decision"
+        },
+        "decision_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "effect_request_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "gate": {
+          "$ref": "#/$defs/Gate"
+        },
+        "subject_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "decision_id",
+        "gate",
+        "effect_request_digest",
+        "subject_digest",
+        "decision"
+      ],
+      "type": "object"
+    },
+    "ProtectedEffectResultBody": {
+      "additionalProperties": false,
+      "description": "Canonical digest preimage containing one protected effect result.",
+      "properties": {
+        "agent_run_request_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "decision": {
+          "$ref": "#/$defs/ProtectedEffectDecision"
+        },
+        "effect_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "effect_request_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "effect_sequence": {
+          "format": "uint64",
+          "maximum": 9007199254740991,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/EffectEvidenceReference"
+          },
+          "type": "array"
+        },
+        "execution_status": {
+          "$ref": "#/$defs/EffectExecutionStatus"
+        },
+        "executor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExecutorIdentity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "exit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EffectExit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "observed_capability": {
+          "$ref": "#/$defs/CapabilityIdentity"
+        },
+        "observed_post_effect_subject": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Subject"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "observed_pre_effect_subject": {
+          "$ref": "#/$defs/Subject"
+        },
+        "observed_tool_schema_digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sandbox_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SandboxProfileIdentity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema_version": {
+          "const": "gaap.protected-effect-result/0.1.0",
+          "type": "string"
+        },
+        "usage": {
+          "$ref": "#/$defs/EffectUsage"
+        }
+      },
+      "required": [
+        "schema_version",
+        "effect_id",
+        "effect_sequence",
+        "run_id",
+        "agent_run_request_digest",
+        "effect_request_digest",
+        "observed_pre_effect_subject",
+        "observed_capability",
+        "decision",
+        "execution_status",
+        "usage",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "SandboxProfileIdentity": {
+      "additionalProperties": false,
+      "description": "Exact sandbox profile requested for any eventual execution.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "Subject": {
+      "additionalProperties": false,
+      "description": "Exact repository or artifact that the Agent Run may inspect or change.",
+      "properties": {
+        "digest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/SubjectKind"
+        },
+        "locator": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "locator",
+        "digest"
+      ],
+      "type": "object"
+    },
+    "SubjectKind": {
+      "description": "Closed subject categories supported by contract version 0.1.0.",
+      "enum": [
+        "repository",
+        "artifact"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/protected-effect/v0.1.0/protected-effect-result.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Content-addressed envelope around a canonical Protected Effect Result body.",
+  "properties": {
+    "body": {
+      "$ref": "#/$defs/ProtectedEffectResultBody"
+    },
+    "result_digest": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "result_digest",
+    "body"
+  ],
+  "title": "GAAP Protected Effect Result 0.1.0",
+  "type": "object"
+}

--- a/src/contracts/canonical.rs
+++ b/src/contracts/canonical.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use super::model::{AgentRunRequest, ResourceBudget, TerminalRunReceiptBody};
-use super::protected_effect::ProtectedEffectRequest;
+use super::protected_effect::{ProtectedEffectRequest, ProtectedEffectResultBody};
 use super::validation::{ContractError, ContractErrorCode};
 
 /// Serialize an Agent Run Request using RFC 8785 JSON Canonicalization Scheme.
@@ -20,6 +20,13 @@ pub fn canonical_protected_effect_request_bytes(
 /// Return the canonical content digest of one Agent Run resource budget.
 pub fn canonical_resource_budget_digest(budget: &ResourceBudget) -> Result<String, ContractError> {
     canonical_bytes(budget).map(|bytes| sha256_digest(&bytes))
+}
+
+/// Serialize a Protected Effect Result body using RFC 8785 JSON Canonicalization Scheme.
+pub fn canonical_protected_effect_result_body_bytes(
+    body: &ProtectedEffectResultBody,
+) -> Result<Vec<u8>, ContractError> {
+    canonical_bytes(body)
 }
 
 pub(crate) fn canonical_receipt_body_bytes(

--- a/src/contracts/canonical.rs
+++ b/src/contracts/canonical.rs
@@ -1,12 +1,25 @@
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use super::model::{AgentRunRequest, TerminalRunReceiptBody};
+use super::model::{AgentRunRequest, ResourceBudget, TerminalRunReceiptBody};
+use super::protected_effect::ProtectedEffectRequest;
 use super::validation::{ContractError, ContractErrorCode};
 
 /// Serialize an Agent Run Request using RFC 8785 JSON Canonicalization Scheme.
 pub fn canonical_request_bytes(request: &AgentRunRequest) -> Result<Vec<u8>, ContractError> {
     canonical_bytes(request)
+}
+
+/// Serialize a Protected Effect Request using RFC 8785 JSON Canonicalization Scheme.
+pub fn canonical_protected_effect_request_bytes(
+    request: &ProtectedEffectRequest,
+) -> Result<Vec<u8>, ContractError> {
+    canonical_bytes(request)
+}
+
+/// Return the canonical content digest of one Agent Run resource budget.
+pub fn canonical_resource_budget_digest(budget: &ResourceBudget) -> Result<String, ContractError> {
+    canonical_bytes(budget).map(|bytes| sha256_digest(&bytes))
 }
 
 pub(crate) fn canonical_receipt_body_bytes(

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -7,8 +7,8 @@ mod schema;
 mod validation;
 
 pub use canonical::{
-    canonical_protected_effect_request_bytes, canonical_request_bytes,
-    canonical_resource_budget_digest,
+    canonical_protected_effect_request_bytes, canonical_protected_effect_result_body_bytes,
+    canonical_request_bytes, canonical_resource_budget_digest,
 };
 pub use model::{
     AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, AgentRunStatus, ApprovalReference,
@@ -18,9 +18,14 @@ pub use model::{
     VerificationVerdict,
 };
 pub use protected_effect::{
-    EffectClass, FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
-    PROTECTED_EFFECT_REQUEST_SCHEMA, ProtectedEffectRequest, Repeatability, RequestedScope,
-    SandboxProfileIdentity, parse_protected_effect_request_json, validate_protected_effect_request,
+    EffectClass, EffectEvidenceReference, EffectEvidenceType, EffectExecutionStatus, EffectExit,
+    EffectUsage, ExecutorIdentity, FilesystemAccess, InputMetadataEntry, NetworkProtocol,
+    OperationFamily, PROTECTED_EFFECT_REQUEST_SCHEMA, PROTECTED_EFFECT_RESULT_SCHEMA,
+    ProtectedEffectDecision, ProtectedEffectRequest, ProtectedEffectResult,
+    ProtectedEffectResultBody, Repeatability, RequestedScope, SandboxProfileIdentity,
+    parse_protected_effect_request_json, parse_protected_effect_result_json,
+    seal_protected_effect_result, validate_protected_effect_request,
+    validate_protected_effect_result_body, verify_protected_effect_result,
 };
 pub use schema::{agent_run_request_schema, terminal_run_receipt_schema};
 pub use validation::{

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -2,7 +2,7 @@
 
 mod canonical;
 mod model;
-mod protected_effect;
+pub mod protected_effect;
 mod schema;
 mod validation;
 
@@ -27,7 +27,10 @@ pub use protected_effect::{
     seal_protected_effect_result, validate_protected_effect_request,
     validate_protected_effect_result_body, verify_protected_effect_result,
 };
-pub use schema::{agent_run_request_schema, terminal_run_receipt_schema};
+pub use schema::{
+    agent_run_request_schema, protected_effect_request_schema, protected_effect_result_schema,
+    terminal_run_receipt_schema,
+};
 pub use validation::{
     ContractError, ContractErrorCode, ContractSupport, parse_agent_run_request_json,
     parse_terminal_run_receipt_json, seal_terminal_receipt, validate_request,

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -2,16 +2,25 @@
 
 mod canonical;
 mod model;
+mod protected_effect;
 mod schema;
 mod validation;
 
-pub use canonical::canonical_request_bytes;
+pub use canonical::{
+    canonical_protected_effect_request_bytes, canonical_request_bytes,
+    canonical_resource_budget_digest,
+};
 pub use model::{
     AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, AgentRunStatus, ApprovalReference,
     CapabilityIdentity, EvidenceReference, EvidenceType, PolicyIdentity, ResourceBudget,
     ResourceUsage, RunEvent, Subject, SubjectKind, TERMINAL_RUN_RECEIPT_SCHEMA, TaskSpec,
     TerminalRunReceipt, TerminalRunReceiptBody, VerificationIndependence, VerificationRequirement,
     VerificationVerdict,
+};
+pub use protected_effect::{
+    EffectClass, FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
+    PROTECTED_EFFECT_REQUEST_SCHEMA, ProtectedEffectRequest, Repeatability, RequestedScope,
+    SandboxProfileIdentity, parse_protected_effect_request_json, validate_protected_effect_request,
 };
 pub use schema::{agent_run_request_schema, terminal_run_receipt_schema};
 pub use validation::{

--- a/src/contracts/protected_effect/mod.rs
+++ b/src/contracts/protected_effect/mod.rs
@@ -1,0 +1,11 @@
+//! Canonical contracts for one proposed or observed protected effect.
+
+mod model;
+mod validation;
+
+pub use model::{
+    EffectClass, FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
+    PROTECTED_EFFECT_REQUEST_SCHEMA, ProtectedEffectRequest, Repeatability, RequestedScope,
+    SandboxProfileIdentity,
+};
+pub use validation::{parse_protected_effect_request_json, validate_protected_effect_request};

--- a/src/contracts/protected_effect/mod.rs
+++ b/src/contracts/protected_effect/mod.rs
@@ -1,11 +1,18 @@
 //! Canonical contracts for one proposed or observed protected effect.
 
 mod model;
+mod result_validation;
 mod validation;
 
 pub use model::{
-    EffectClass, FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
-    PROTECTED_EFFECT_REQUEST_SCHEMA, ProtectedEffectRequest, Repeatability, RequestedScope,
-    SandboxProfileIdentity,
+    EffectClass, EffectEvidenceReference, EffectEvidenceType, EffectExecutionStatus, EffectExit,
+    EffectUsage, ExecutorIdentity, FilesystemAccess, InputMetadataEntry, NetworkProtocol,
+    OperationFamily, PROTECTED_EFFECT_REQUEST_SCHEMA, PROTECTED_EFFECT_RESULT_SCHEMA,
+    ProtectedEffectDecision, ProtectedEffectRequest, ProtectedEffectResult,
+    ProtectedEffectResultBody, Repeatability, RequestedScope, SandboxProfileIdentity,
+};
+pub use result_validation::{
+    parse_protected_effect_result_json, seal_protected_effect_result,
+    validate_protected_effect_result_body, verify_protected_effect_result,
 };
 pub use validation::{parse_protected_effect_request_json, validate_protected_effect_request};

--- a/src/contracts/protected_effect/mod.rs
+++ b/src/contracts/protected_effect/mod.rs
@@ -4,6 +4,11 @@ mod model;
 mod result_validation;
 mod validation;
 
+pub use super::canonical::{
+    canonical_protected_effect_request_bytes, canonical_protected_effect_result_body_bytes,
+    canonical_resource_budget_digest,
+};
+pub use super::schema::{protected_effect_request_schema, protected_effect_result_schema};
 pub use model::{
     EffectClass, EffectEvidenceReference, EffectEvidenceType, EffectExecutionStatus, EffectExit,
     EffectUsage, ExecutorIdentity, FilesystemAccess, InputMetadataEntry, NetworkProtocol,

--- a/src/contracts/protected_effect/model.rs
+++ b/src/contracts/protected_effect/model.rs
@@ -2,8 +2,10 @@ use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
 
 use super::super::model::{ApprovalReference, CapabilityIdentity, PolicyIdentity, Subject};
+use crate::{Decision, Gate};
 
 pub const PROTECTED_EFFECT_REQUEST_SCHEMA: &str = "gaap.protected-effect-request/0.1.0";
+pub const PROTECTED_EFFECT_RESULT_SCHEMA: &str = "gaap.protected-effect-result/0.1.0";
 
 /// One protected effect proposed inside a governed Agent Run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -160,6 +162,143 @@ pub struct SandboxProfileIdentity {
     pub digest: String,
 }
 
+/// The decisive RunCoordinator record bound to an exact effect request and subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProtectedEffectDecision {
+    #[schemars(length(min = 1))]
+    pub decision_id: String,
+    pub gate: Gate,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub effect_request_digest: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub subject_digest: String,
+    pub decision: Decision,
+}
+
+/// Closed execution outcomes supported by Protected Effect Result 0.1.0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectExecutionStatus {
+    Executed,
+    AwaitingAuthority,
+    Denied,
+    Failed,
+    Interrupted,
+    UnknownOutcome,
+}
+
+/// A known process exit, represented without provider-specific status types.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "exit_type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EffectExit {
+    Code {
+        code: i32,
+    },
+    Signal {
+        #[schemars(length(min = 1))]
+        signal: String,
+    },
+}
+
+/// Exact executor identity observed for an attempted protected effect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutorIdentity {
+    #[schemars(length(min = 1))]
+    pub name: String,
+    #[schemars(length(min = 1))]
+    pub version: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub digest: String,
+}
+
+/// Closed evidence categories supported by Protected Effect Result 0.1.0.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectEvidenceType {
+    Exit,
+    Output,
+    Artifact,
+    Mutation,
+    Usage,
+    Executor,
+    Sandbox,
+    Failure,
+    Interruption,
+    SubjectObservation,
+    CapabilitySchema,
+    UnknownOutcome,
+}
+
+/// Content-addressed effect evidence metadata; raw evidence remains external.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EffectEvidenceReference {
+    pub evidence_type: EffectEvidenceType,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub digest: String,
+    #[schemars(inner(length(min = 1)))]
+    pub locator: Option<String>,
+}
+
+/// Resource usage attributable only to this protected effect attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EffectUsage {
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub cost_micros: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub elapsed_ms: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub model_tokens: u64,
+    #[schemars(range(max = 9007199254740991_u64))]
+    pub tool_calls: u64,
+}
+
+/// Canonical digest preimage containing one protected effect result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProtectedEffectResultBody {
+    #[schemars(schema_with = "protected_effect_result_schema_version")]
+    pub schema_version: String,
+    #[schemars(length(min = 1))]
+    pub effect_id: String,
+    #[schemars(range(min = 1, max = 9007199254740991_u64))]
+    pub effect_sequence: u64,
+    #[schemars(length(min = 1))]
+    pub run_id: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub agent_run_request_digest: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub effect_request_digest: String,
+    pub observed_pre_effect_subject: Subject,
+    pub observed_capability: CapabilityIdentity,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub observed_tool_schema_digest: Option<String>,
+    pub decision: ProtectedEffectDecision,
+    pub execution_status: EffectExecutionStatus,
+    pub observed_post_effect_subject: Option<Subject>,
+    pub exit: Option<EffectExit>,
+    pub usage: EffectUsage,
+    pub executor: Option<ExecutorIdentity>,
+    pub sandbox_profile: Option<SandboxProfileIdentity>,
+    #[schemars(inner(length(min = 1)))]
+    pub reason: Option<String>,
+    pub evidence: Vec<EffectEvidenceReference>,
+}
+
+/// Content-addressed envelope around a canonical Protected Effect Result body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProtectedEffectResult {
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub result_digest: String,
+    pub body: ProtectedEffectResultBody,
+}
+
 fn protected_effect_request_schema_version(_generator: &mut SchemaGenerator) -> Schema {
     serde_json::json!({
         "type": "string",
@@ -167,4 +306,13 @@ fn protected_effect_request_schema_version(_generator: &mut SchemaGenerator) -> 
     })
     .try_into()
     .expect("Protected Effect Request schema version must be valid JSON Schema")
+}
+
+fn protected_effect_result_schema_version(_generator: &mut SchemaGenerator) -> Schema {
+    serde_json::json!({
+        "type": "string",
+        "const": PROTECTED_EFFECT_RESULT_SCHEMA,
+    })
+    .try_into()
+    .expect("Protected Effect Result schema version must be valid JSON Schema")
 }

--- a/src/contracts/protected_effect/model.rs
+++ b/src/contracts/protected_effect/model.rs
@@ -1,0 +1,170 @@
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use serde::{Deserialize, Serialize};
+
+use super::super::model::{ApprovalReference, CapabilityIdentity, PolicyIdentity, Subject};
+
+pub const PROTECTED_EFFECT_REQUEST_SCHEMA: &str = "gaap.protected-effect-request/0.1.0";
+
+/// One protected effect proposed inside a governed Agent Run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProtectedEffectRequest {
+    #[schemars(schema_with = "protected_effect_request_schema_version")]
+    pub schema_version: String,
+    #[schemars(length(min = 1))]
+    pub effect_id: String,
+    #[schemars(range(min = 1, max = 9007199254740991_u64))]
+    pub effect_sequence: u64,
+    #[schemars(length(min = 1))]
+    pub run_id: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub agent_run_request_digest: String,
+    pub subject: Subject,
+    pub operation_family: OperationFamily,
+    #[schemars(length(min = 1))]
+    pub normalized_operation: String,
+    pub capability: CapabilityIdentity,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub tool_schema_digest: Option<String>,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub input_digest: String,
+    #[schemars(length(max = 32))]
+    pub input_metadata: Vec<InputMetadataEntry>,
+    #[schemars(length(min = 1))]
+    pub requested_scopes: Vec<RequestedScope>,
+    #[schemars(length(min = 1))]
+    pub policies: Vec<PolicyIdentity>,
+    pub approval_context: Vec<ApprovalReference>,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub resource_budget_digest: String,
+    pub sandbox_profile: SandboxProfileIdentity,
+    #[schemars(length(min = 1))]
+    pub idempotency_key: String,
+    pub repeatability: Repeatability,
+    pub expected_effect_class: EffectClass,
+}
+
+/// Closed operation families supported by Protected Effect Request 0.1.0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationFamily {
+    Filesystem,
+    Process,
+    Network,
+    ExternalService,
+}
+
+impl OperationFamily {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Filesystem => "filesystem",
+            Self::Process => "process",
+            Self::Network => "network",
+            Self::ExternalService => "external_service",
+        }
+    }
+}
+
+/// Bounded non-secret metadata describing external normalized input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InputMetadataEntry {
+    #[schemars(length(min = 1, max = 64))]
+    pub name: String,
+    #[schemars(length(min = 1, max = 256))]
+    pub value: String,
+}
+
+/// One exact resource boundary requested by a protected effect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "scope_type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RequestedScope {
+    Filesystem {
+        #[schemars(length(min = 1))]
+        root: String,
+        #[schemars(length(min = 1))]
+        access: Vec<FilesystemAccess>,
+        recursive: bool,
+    },
+    Process {
+        #[schemars(length(min = 1))]
+        executable: String,
+        #[schemars(length(min = 1))]
+        working_directory: String,
+    },
+    Network {
+        protocol: NetworkProtocol,
+        #[schemars(length(min = 1))]
+        host: String,
+        #[schemars(range(min = 1))]
+        port: u16,
+    },
+    ExternalService {
+        #[schemars(length(min = 1))]
+        service: String,
+        #[schemars(length(min = 1))]
+        operation: String,
+        #[schemars(length(min = 1))]
+        resource: String,
+    },
+}
+
+/// Filesystem authority classes supported by the typed scope contract.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum FilesystemAccess {
+    Read,
+    Create,
+    Modify,
+    Delete,
+}
+
+/// Network protocols supported by the typed scope contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProtocol {
+    Tcp,
+    Udp,
+    Http,
+    Https,
+}
+
+/// How the future runtime may reason about repeating an identical request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Repeatability {
+    Repeatable,
+    Idempotent,
+    NonRepeatable,
+}
+
+/// Whether the proposed effect is expected to observe or mutate its subject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectClass {
+    Observation,
+    Mutation,
+}
+
+/// Exact sandbox profile requested for any eventual execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxProfileIdentity {
+    #[schemars(length(min = 1))]
+    pub name: String,
+    #[schemars(length(min = 1))]
+    pub version: String,
+    #[schemars(regex(pattern = r"^sha256:[0-9a-f]{64}$"))]
+    pub digest: String,
+}
+
+fn protected_effect_request_schema_version(_generator: &mut SchemaGenerator) -> Schema {
+    serde_json::json!({
+        "type": "string",
+        "const": PROTECTED_EFFECT_REQUEST_SCHEMA,
+    })
+    .try_into()
+    .expect("Protected Effect Request schema version must be valid JSON Schema")
+}

--- a/src/contracts/protected_effect/result_validation.rs
+++ b/src/contracts/protected_effect/result_validation.rs
@@ -13,7 +13,7 @@ use super::model::{
     SandboxProfileIdentity,
 };
 use super::validation::validate_protected_effect_request;
-use crate::Outcome;
+use crate::{Gate, Outcome};
 
 const STALE_SUBJECT_REASON: &str = "protected_effect.stale_subject";
 const SCHEMA_DRIFT_REASON: &str = "protected_effect.capability_schema_drift";
@@ -46,6 +46,7 @@ pub fn validate_protected_effect_result_body(
     validate_decision(&effect_request_digest, body)?;
     validate_usage(&body.usage)?;
     validate_evidence(&body.evidence)?;
+    validate_operation_specific_result(request, body)?;
 
     let subject_drift = body.observed_pre_effect_subject != request.subject;
     if body.observed_capability != request.capability {
@@ -211,6 +212,13 @@ fn validate_status_matrix(
                 "{:?} requires a {expected_outcome:?} decision",
                 body.execution_status
             ),
+        ));
+    }
+    if expected_outcome == Outcome::Allow && body.decision.gate != Gate::Permission {
+        return Err(ContractError::new(
+            ContractErrorCode::UnauthorizedEffect,
+            "body.decision.gate",
+            "an attempted effect requires an allow decision from the permission gate",
         ));
     }
 
@@ -423,13 +431,42 @@ fn validate_known_post_effect(
             EffectEvidenceType::Exit,
             "known process result requires exit evidence",
         )?;
-    } else if let Some(exit) = &body.exit {
+    } else if request.operation_family == OperationFamily::Process
+        && let Some(exit) = &body.exit
+    {
         validate_exit(exit)?;
         require_evidence(
             body,
             EffectEvidenceType::Exit,
             "recorded exit status requires exit evidence",
         )?;
+    }
+    Ok(())
+}
+
+fn validate_operation_specific_result(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    if request.operation_family == OperationFamily::Process {
+        return Ok(());
+    }
+    if body.exit.is_some() {
+        return Err(invalid_contract(
+            "body.exit",
+            "only process effects may record an exit status",
+        ));
+    }
+    if let Some((index, _)) = body
+        .evidence
+        .iter()
+        .enumerate()
+        .find(|(_, reference)| reference.evidence_type == EffectEvidenceType::Exit)
+    {
+        return Err(invalid_contract(
+            format!("body.evidence[{index}].evidence_type"),
+            "only process effects may record exit evidence",
+        ));
     }
     Ok(())
 }

--- a/src/contracts/protected_effect/result_validation.rs
+++ b/src/contracts/protected_effect/result_validation.rs
@@ -1,0 +1,634 @@
+use std::collections::BTreeSet;
+
+use super::super::canonical::{canonical_protected_effect_result_body_bytes, sha256_digest};
+use super::super::model::{AgentRunRequest, CapabilityIdentity, Subject};
+use super::super::validation::{
+    ContractError, ContractErrorCode, ContractSupport, validate_digest, validate_non_empty,
+    validate_safe_integer,
+};
+use super::model::{
+    EffectClass, EffectEvidenceReference, EffectEvidenceType, EffectExecutionStatus, EffectExit,
+    EffectUsage, ExecutorIdentity, OperationFamily, PROTECTED_EFFECT_RESULT_SCHEMA,
+    ProtectedEffectRequest, ProtectedEffectResult, ProtectedEffectResultBody,
+    SandboxProfileIdentity,
+};
+use super::validation::validate_protected_effect_request;
+use crate::Outcome;
+
+const STALE_SUBJECT_REASON: &str = "protected_effect.stale_subject";
+const SCHEMA_DRIFT_REASON: &str = "protected_effect.capability_schema_drift";
+const COMBINED_DRIFT_REASON: &str = "protected_effect.subject_and_capability_schema_drift";
+
+/// Strictly parse a Protected Effect Result from UTF-8 JSON bytes.
+pub fn parse_protected_effect_result_json(
+    bytes: &[u8],
+) -> Result<ProtectedEffectResult, ContractError> {
+    serde_json::from_slice(bytes).map_err(|error| {
+        ContractError::new(
+            ContractErrorCode::InvalidJson,
+            "$",
+            format!("invalid Protected Effect Result JSON: {error}"),
+        )
+    })
+}
+
+/// Validate a result body and its exact binding to a protected effect request.
+pub fn validate_protected_effect_result_body(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    let effect_request_digest =
+        validate_protected_effect_request(agent_run_request, support, request)?;
+    validate_result_identity(request, &effect_request_digest, body)?;
+    validate_observed_identities(body)?;
+    validate_decision(&effect_request_digest, body)?;
+    validate_usage(&body.usage)?;
+    validate_evidence(&body.evidence)?;
+
+    let subject_drift = body.observed_pre_effect_subject != request.subject;
+    if body.observed_capability != request.capability {
+        return Err(request_mismatch("body.observed_capability"));
+    }
+    let schema_drift = body.observed_tool_schema_digest != request.tool_schema_digest;
+    validate_drift(body, subject_drift, schema_drift)?;
+    validate_status_matrix(request, body)?;
+    Ok(())
+}
+
+/// Validate and seal one immutable Protected Effect Result body.
+pub fn seal_protected_effect_result(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    body: ProtectedEffectResultBody,
+) -> Result<ProtectedEffectResult, ContractError> {
+    validate_protected_effect_result_body(agent_run_request, support, request, &body)?;
+    let result_digest = sha256_digest(&canonical_protected_effect_result_body_bytes(&body)?);
+    Ok(ProtectedEffectResult {
+        result_digest,
+        body,
+    })
+}
+
+/// Verify a result digest and its semantic binding to one exact effect request.
+pub fn verify_protected_effect_result(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+    result: &ProtectedEffectResult,
+) -> Result<(), ContractError> {
+    validate_digest(&result.result_digest, "result_digest").map_err(|_| {
+        ContractError::new(
+            ContractErrorCode::ResultTampering,
+            "result_digest",
+            "result digest is malformed",
+        )
+    })?;
+    let actual_digest = sha256_digest(&canonical_protected_effect_result_body_bytes(&result.body)?);
+    if actual_digest != result.result_digest {
+        return Err(ContractError::new(
+            ContractErrorCode::ResultTampering,
+            "result_digest",
+            format!(
+                "result digest mismatch: expected {}, calculated {actual_digest}",
+                result.result_digest
+            ),
+        ));
+    }
+    validate_protected_effect_result_body(agent_run_request, support, request, &result.body)
+}
+
+fn validate_result_identity(
+    request: &ProtectedEffectRequest,
+    effect_request_digest: &str,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    if body.schema_version != PROTECTED_EFFECT_RESULT_SCHEMA {
+        return Err(ContractError::new(
+            ContractErrorCode::UnsupportedSchema,
+            "body.schema_version",
+            format!(
+                "unsupported Protected Effect Result schema: {}",
+                body.schema_version
+            ),
+        ));
+    }
+    validate_non_empty(&body.effect_id, "body.effect_id")?;
+    if body.effect_id != request.effect_id {
+        return Err(request_mismatch("body.effect_id"));
+    }
+    validate_safe_integer(body.effect_sequence, "body.effect_sequence")?;
+    if body.effect_sequence == 0 || body.effect_sequence != request.effect_sequence {
+        return Err(request_mismatch("body.effect_sequence"));
+    }
+    validate_non_empty(&body.run_id, "body.run_id")?;
+    if body.run_id != request.run_id {
+        return Err(request_mismatch("body.run_id"));
+    }
+    validate_digest(
+        &body.agent_run_request_digest,
+        "body.agent_run_request_digest",
+    )?;
+    if body.agent_run_request_digest != request.agent_run_request_digest {
+        return Err(request_mismatch("body.agent_run_request_digest"));
+    }
+    validate_digest(&body.effect_request_digest, "body.effect_request_digest")?;
+    if body.effect_request_digest != effect_request_digest {
+        return Err(request_mismatch("body.effect_request_digest"));
+    }
+    Ok(())
+}
+
+fn validate_observed_identities(body: &ProtectedEffectResultBody) -> Result<(), ContractError> {
+    validate_subject(
+        &body.observed_pre_effect_subject,
+        "body.observed_pre_effect_subject",
+    )?;
+    validate_capability(&body.observed_capability, "body.observed_capability")?;
+    if let Some(digest) = &body.observed_tool_schema_digest {
+        validate_digest(digest, "body.observed_tool_schema_digest")?;
+    }
+    if let Some(subject) = &body.observed_post_effect_subject {
+        validate_subject(subject, "body.observed_post_effect_subject")?;
+    }
+    Ok(())
+}
+
+fn validate_decision(
+    effect_request_digest: &str,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    let decision = &body.decision;
+    validate_non_empty(&decision.decision_id, "body.decision.decision_id")?;
+    validate_digest(
+        &decision.effect_request_digest,
+        "body.decision.effect_request_digest",
+    )?;
+    if decision.effect_request_digest != effect_request_digest {
+        return Err(request_mismatch("body.decision.effect_request_digest"));
+    }
+    validate_digest(&decision.subject_digest, "body.decision.subject_digest")?;
+    if decision.subject_digest != body.observed_pre_effect_subject.digest {
+        return Err(request_mismatch("body.decision.subject_digest"));
+    }
+    validate_non_empty(&decision.decision.code, "body.decision.decision.code")?;
+    for (index, effect) in decision.decision.effects.iter().enumerate() {
+        validate_non_empty(effect, &format!("body.decision.decision.effects[{index}]"))?;
+    }
+    Ok(())
+}
+
+fn validate_status_matrix(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    let expected_outcome = match body.execution_status {
+        EffectExecutionStatus::Executed
+        | EffectExecutionStatus::Failed
+        | EffectExecutionStatus::Interrupted
+        | EffectExecutionStatus::UnknownOutcome => Outcome::Allow,
+        EffectExecutionStatus::AwaitingAuthority => Outcome::Ask,
+        EffectExecutionStatus::Denied => Outcome::Block,
+    };
+    if body.decision.decision.outcome != expected_outcome {
+        let code = if matches!(
+            body.execution_status,
+            EffectExecutionStatus::Executed
+                | EffectExecutionStatus::Failed
+                | EffectExecutionStatus::Interrupted
+                | EffectExecutionStatus::UnknownOutcome
+        ) {
+            ContractErrorCode::UnauthorizedEffect
+        } else {
+            ContractErrorCode::InvalidContract
+        };
+        return Err(ContractError::new(
+            code,
+            "body.decision.decision.outcome",
+            format!(
+                "{:?} requires a {expected_outcome:?} decision",
+                body.execution_status
+            ),
+        ));
+    }
+
+    match body.execution_status {
+        EffectExecutionStatus::Executed => validate_executed(request, body),
+        EffectExecutionStatus::AwaitingAuthority | EffectExecutionStatus::Denied => {
+            validate_non_execution(body)
+        }
+        EffectExecutionStatus::Failed => validate_known_attempt(
+            request,
+            body,
+            EffectEvidenceType::Failure,
+            &[
+                EffectEvidenceType::Interruption,
+                EffectEvidenceType::UnknownOutcome,
+            ],
+            "failed result requires failure evidence",
+        ),
+        EffectExecutionStatus::Interrupted => validate_known_attempt(
+            request,
+            body,
+            EffectEvidenceType::Interruption,
+            &[
+                EffectEvidenceType::Failure,
+                EffectEvidenceType::UnknownOutcome,
+            ],
+            "interrupted result requires interruption evidence",
+        ),
+        EffectExecutionStatus::UnknownOutcome => validate_unknown_attempt(request, body),
+    }
+}
+
+fn validate_executed(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    if body.reason.is_some() {
+        return Err(invalid_contract(
+            "body.reason",
+            "executed result must not contain a failure reason",
+        ));
+    }
+    validate_attempt_common(request, body)?;
+    validate_known_post_effect(request, body)?;
+    reject_evidence_types(
+        body,
+        &[
+            EffectEvidenceType::Failure,
+            EffectEvidenceType::Interruption,
+            EffectEvidenceType::UnknownOutcome,
+        ],
+    )
+}
+
+fn validate_non_execution(body: &ProtectedEffectResultBody) -> Result<(), ContractError> {
+    validate_reason(body)?;
+    if body.observed_post_effect_subject.is_some() {
+        return Err(unauthorized("body.observed_post_effect_subject"));
+    }
+    if body.exit.is_some() {
+        return Err(unauthorized("body.exit"));
+    }
+    if !usage_is_zero(&body.usage) {
+        return Err(unauthorized("body.usage"));
+    }
+    if body.executor.is_some() {
+        return Err(unauthorized("body.executor"));
+    }
+    if body.sandbox_profile.is_some() {
+        return Err(unauthorized("body.sandbox_profile"));
+    }
+    for (index, reference) in body.evidence.iter().enumerate() {
+        if evidence_is_execution_derived(reference.evidence_type) {
+            return Err(unauthorized(format!(
+                "body.evidence[{index}].evidence_type"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_known_attempt(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+    required_evidence: EffectEvidenceType,
+    rejected_evidence: &[EffectEvidenceType],
+    message: &str,
+) -> Result<(), ContractError> {
+    validate_reason(body)?;
+    validate_attempt_common(request, body)?;
+    validate_known_post_effect(request, body)?;
+    require_evidence(body, required_evidence, message)?;
+    reject_evidence_types(body, rejected_evidence)
+}
+
+fn validate_unknown_attempt(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    validate_reason(body)?;
+    validate_attempt_common(request, body)?;
+    require_evidence(
+        body,
+        EffectEvidenceType::UnknownOutcome,
+        "unknown outcome requires unknown_outcome evidence",
+    )?;
+    reject_evidence_types(
+        body,
+        &[
+            EffectEvidenceType::Failure,
+            EffectEvidenceType::Interruption,
+        ],
+    )?;
+    if body.exit.is_some() {
+        return Err(invalid_contract(
+            "body.exit",
+            "unknown outcome must not claim a known process exit",
+        ));
+    }
+    if body.observed_post_effect_subject.is_some() {
+        validate_known_post_effect(request, body)?;
+    }
+    Ok(())
+}
+
+fn validate_attempt_common(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    let executor = body
+        .executor
+        .as_ref()
+        .ok_or_else(|| invalid_contract("body.executor", "attempt requires executor identity"))?;
+    validate_executor(executor)?;
+    require_evidence(
+        body,
+        EffectEvidenceType::Executor,
+        "attempt requires executor evidence",
+    )?;
+    let sandbox = body.sandbox_profile.as_ref().ok_or_else(|| {
+        invalid_contract("body.sandbox_profile", "attempt requires sandbox identity")
+    })?;
+    validate_sandbox(sandbox)?;
+    if sandbox != &request.sandbox_profile {
+        return Err(request_mismatch("body.sandbox_profile"));
+    }
+    require_evidence(
+        body,
+        EffectEvidenceType::Sandbox,
+        "attempt requires sandbox evidence",
+    )?;
+    require_evidence(
+        body,
+        EffectEvidenceType::Usage,
+        "attempt requires usage evidence",
+    )?;
+    Ok(())
+}
+
+fn validate_known_post_effect(
+    request: &ProtectedEffectRequest,
+    body: &ProtectedEffectResultBody,
+) -> Result<(), ContractError> {
+    let post_subject = body.observed_post_effect_subject.as_ref().ok_or_else(|| {
+        invalid_contract(
+            "body.observed_post_effect_subject",
+            "known outcome requires a post-effect subject observation",
+        )
+    })?;
+    require_evidence(
+        body,
+        EffectEvidenceType::SubjectObservation,
+        "known post-effect subject requires subject_observation evidence",
+    )?;
+    match request.expected_effect_class {
+        EffectClass::Observation => {
+            if post_subject.digest != request.subject.digest {
+                return Err(invalid_contract(
+                    "body.observed_post_effect_subject",
+                    "observation result must preserve the requested subject digest",
+                ));
+            }
+        }
+        EffectClass::Mutation => {
+            require_evidence(
+                body,
+                EffectEvidenceType::Mutation,
+                "mutation result requires mutation evidence",
+            )?;
+            require_evidence(
+                body,
+                EffectEvidenceType::Artifact,
+                "mutation result requires artifact evidence",
+            )?;
+        }
+    }
+
+    if request.operation_family == OperationFamily::Process
+        && matches!(
+            body.execution_status,
+            EffectExecutionStatus::Executed | EffectExecutionStatus::Failed
+        )
+    {
+        let exit = body.exit.as_ref().ok_or_else(|| {
+            invalid_contract("body.exit", "known process result requires an exit status")
+        })?;
+        validate_exit(exit)?;
+        require_evidence(
+            body,
+            EffectEvidenceType::Exit,
+            "known process result requires exit evidence",
+        )?;
+    } else if let Some(exit) = &body.exit {
+        validate_exit(exit)?;
+        require_evidence(
+            body,
+            EffectEvidenceType::Exit,
+            "recorded exit status requires exit evidence",
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_drift(
+    body: &ProtectedEffectResultBody,
+    subject_drift: bool,
+    schema_drift: bool,
+) -> Result<(), ContractError> {
+    if !subject_drift && !schema_drift {
+        if matches!(
+            body.reason.as_deref(),
+            Some(STALE_SUBJECT_REASON | SCHEMA_DRIFT_REASON | COMBINED_DRIFT_REASON)
+        ) {
+            return Err(invalid_contract(
+                "body.reason",
+                "drift denial reason requires a requested-versus-observed identity difference",
+            ));
+        }
+        return Ok(());
+    }
+    if body.execution_status != EffectExecutionStatus::Denied {
+        let path = if subject_drift {
+            "body.observed_pre_effect_subject"
+        } else {
+            "body.observed_tool_schema_digest"
+        };
+        return Err(request_mismatch(path));
+    }
+
+    let expected_reason = match (subject_drift, schema_drift) {
+        (true, false) => STALE_SUBJECT_REASON,
+        (false, true) => SCHEMA_DRIFT_REASON,
+        (true, true) => COMBINED_DRIFT_REASON,
+        (false, false) => unreachable!("drift validation is called only when drift exists"),
+    };
+    if body.reason.as_deref() != Some(expected_reason) {
+        return Err(invalid_contract(
+            "body.reason",
+            format!("drift denial requires reason {expected_reason}"),
+        ));
+    }
+    if subject_drift {
+        require_evidence(
+            body,
+            EffectEvidenceType::SubjectObservation,
+            "stale-subject denial requires subject_observation evidence",
+        )?;
+    }
+    if schema_drift {
+        require_evidence(
+            body,
+            EffectEvidenceType::CapabilitySchema,
+            "schema-drift denial requires capability_schema evidence",
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_subject(subject: &Subject, path: &str) -> Result<(), ContractError> {
+    validate_non_empty(&subject.locator, &format!("{path}.locator"))?;
+    validate_digest(&subject.digest, &format!("{path}.digest"))
+}
+
+fn validate_capability(capability: &CapabilityIdentity, path: &str) -> Result<(), ContractError> {
+    validate_non_empty(&capability.name, &format!("{path}.name"))?;
+    validate_non_empty(&capability.version, &format!("{path}.version"))?;
+    validate_digest(&capability.digest, &format!("{path}.digest"))
+}
+
+fn validate_executor(executor: &ExecutorIdentity) -> Result<(), ContractError> {
+    validate_non_empty(&executor.name, "body.executor.name")?;
+    validate_non_empty(&executor.version, "body.executor.version")?;
+    validate_digest(&executor.digest, "body.executor.digest")
+}
+
+fn validate_sandbox(sandbox: &SandboxProfileIdentity) -> Result<(), ContractError> {
+    validate_non_empty(&sandbox.name, "body.sandbox_profile.name")?;
+    validate_non_empty(&sandbox.version, "body.sandbox_profile.version")?;
+    validate_digest(&sandbox.digest, "body.sandbox_profile.digest")
+}
+
+fn validate_exit(exit: &EffectExit) -> Result<(), ContractError> {
+    match exit {
+        EffectExit::Code { .. } => Ok(()),
+        EffectExit::Signal { signal } => validate_non_empty(signal, "body.exit.signal"),
+    }
+}
+
+fn validate_usage(usage: &EffectUsage) -> Result<(), ContractError> {
+    validate_safe_integer(usage.cost_micros, "body.usage.cost_micros")?;
+    validate_safe_integer(usage.elapsed_ms, "body.usage.elapsed_ms")?;
+    validate_safe_integer(usage.model_tokens, "body.usage.model_tokens")?;
+    validate_safe_integer(usage.tool_calls, "body.usage.tool_calls")
+}
+
+fn validate_evidence(evidence: &[EffectEvidenceReference]) -> Result<(), ContractError> {
+    let mut identities = BTreeSet::new();
+    for (index, reference) in evidence.iter().enumerate() {
+        let path = format!("body.evidence[{index}]");
+        validate_digest(&reference.digest, &format!("{path}.digest"))?;
+        if let Some(locator) = &reference.locator {
+            validate_non_empty(locator, &format!("{path}.locator"))?;
+        }
+        if !identities.insert((
+            reference.evidence_type,
+            reference.digest.as_str(),
+            reference.locator.as_deref(),
+        )) {
+            return Err(invalid_contract(
+                path,
+                "duplicate effect evidence reference",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_reason(body: &ProtectedEffectResultBody) -> Result<(), ContractError> {
+    let reason = body
+        .reason
+        .as_ref()
+        .ok_or_else(|| invalid_contract("body.reason", "non-executed result requires a reason"))?;
+    validate_non_empty(reason, "body.reason")
+}
+
+fn require_evidence(
+    body: &ProtectedEffectResultBody,
+    evidence_type: EffectEvidenceType,
+    message: &str,
+) -> Result<(), ContractError> {
+    if body
+        .evidence
+        .iter()
+        .any(|reference| reference.evidence_type == evidence_type)
+    {
+        Ok(())
+    } else {
+        Err(invalid_contract("body.evidence", message))
+    }
+}
+
+fn reject_evidence_types(
+    body: &ProtectedEffectResultBody,
+    rejected: &[EffectEvidenceType],
+) -> Result<(), ContractError> {
+    if let Some((index, _)) = body
+        .evidence
+        .iter()
+        .enumerate()
+        .find(|(_, reference)| rejected.contains(&reference.evidence_type))
+    {
+        return Err(invalid_contract(
+            format!("body.evidence[{index}].evidence_type"),
+            "evidence type contradicts the execution status",
+        ));
+    }
+    Ok(())
+}
+
+fn evidence_is_execution_derived(evidence_type: EffectEvidenceType) -> bool {
+    match evidence_type {
+        EffectEvidenceType::SubjectObservation | EffectEvidenceType::CapabilitySchema => false,
+        EffectEvidenceType::Exit
+        | EffectEvidenceType::Output
+        | EffectEvidenceType::Artifact
+        | EffectEvidenceType::Mutation
+        | EffectEvidenceType::Usage
+        | EffectEvidenceType::Executor
+        | EffectEvidenceType::Sandbox
+        | EffectEvidenceType::Failure
+        | EffectEvidenceType::Interruption
+        | EffectEvidenceType::UnknownOutcome => true,
+    }
+}
+
+fn usage_is_zero(usage: &EffectUsage) -> bool {
+    usage.cost_micros == 0
+        && usage.elapsed_ms == 0
+        && usage.model_tokens == 0
+        && usage.tool_calls == 0
+}
+
+fn request_mismatch(path: &str) -> ContractError {
+    ContractError::new(
+        ContractErrorCode::RequestMismatch,
+        path,
+        "Protected Effect Result does not match the validated effect request",
+    )
+}
+
+fn unauthorized(path: impl Into<String>) -> ContractError {
+    ContractError::new(
+        ContractErrorCode::UnauthorizedEffect,
+        path,
+        "non-execution result contains execution-derived state",
+    )
+}
+
+fn invalid_contract(path: impl Into<String>, message: impl Into<String>) -> ContractError {
+    ContractError::new(ContractErrorCode::InvalidContract, path, message)
+}

--- a/src/contracts/protected_effect/result_validation.rs
+++ b/src/contracts/protected_effect/result_validation.rs
@@ -178,6 +178,20 @@ fn validate_decision(
     for (index, effect) in decision.decision.effects.iter().enumerate() {
         validate_non_empty(effect, &format!("body.decision.decision.effects[{index}]"))?;
     }
+    if matches!(
+        body.execution_status,
+        EffectExecutionStatus::Executed
+            | EffectExecutionStatus::Failed
+            | EffectExecutionStatus::Interrupted
+            | EffectExecutionStatus::UnknownOutcome
+    ) && decision.gate != Gate::Permission
+    {
+        return Err(ContractError::new(
+            ContractErrorCode::UnauthorizedEffect,
+            "body.decision.gate",
+            "an attempted effect requires an allow decision from the permission gate",
+        ));
+    }
     Ok(())
 }
 
@@ -214,14 +228,6 @@ fn validate_status_matrix(
             ),
         ));
     }
-    if expected_outcome == Outcome::Allow && body.decision.gate != Gate::Permission {
-        return Err(ContractError::new(
-            ContractErrorCode::UnauthorizedEffect,
-            "body.decision.gate",
-            "an attempted effect requires an allow decision from the permission gate",
-        ));
-    }
-
     match body.execution_status {
         EffectExecutionStatus::Executed => validate_executed(request, body),
         EffectExecutionStatus::AwaitingAuthority | EffectExecutionStatus::Denied => {
@@ -431,15 +437,15 @@ fn validate_known_post_effect(
             EffectEvidenceType::Exit,
             "known process result requires exit evidence",
         )?;
-    } else if request.operation_family == OperationFamily::Process
-        && let Some(exit) = &body.exit
-    {
-        validate_exit(exit)?;
-        require_evidence(
-            body,
-            EffectEvidenceType::Exit,
-            "recorded exit status requires exit evidence",
-        )?;
+    } else if request.operation_family == OperationFamily::Process {
+        if let Some(exit) = &body.exit {
+            validate_exit(exit)?;
+            require_evidence(
+                body,
+                EffectEvidenceType::Exit,
+                "recorded exit status requires exit evidence",
+            )?;
+        }
     }
     Ok(())
 }

--- a/src/contracts/protected_effect/validation.rs
+++ b/src/contracts/protected_effect/validation.rs
@@ -1,0 +1,287 @@
+use std::collections::BTreeSet;
+
+use super::super::canonical::{
+    canonical_protected_effect_request_bytes, canonical_resource_budget_digest, sha256_digest,
+};
+use super::super::model::{AgentRunRequest, EvidenceType};
+use super::super::validation::{
+    ContractError, ContractErrorCode, ContractSupport, validate_digest, validate_evidence,
+    validate_non_empty, validate_request, validate_safe_integer,
+};
+use super::model::{PROTECTED_EFFECT_REQUEST_SCHEMA, ProtectedEffectRequest, RequestedScope};
+
+const MAX_METADATA_ENTRIES: usize = 32;
+const MAX_METADATA_NAME_CHARS: usize = 64;
+const MAX_METADATA_VALUE_CHARS: usize = 256;
+
+/// Strictly parse a Protected Effect Request from UTF-8 JSON bytes.
+pub fn parse_protected_effect_request_json(
+    bytes: &[u8],
+) -> Result<ProtectedEffectRequest, ContractError> {
+    serde_json::from_slice(bytes).map_err(|error| {
+        ContractError::new(
+            ContractErrorCode::InvalidJson,
+            "$",
+            format!("invalid Protected Effect Request JSON: {error}"),
+        )
+    })
+}
+
+/// Validate one proposed effect against its exact parent Agent Run Request.
+pub fn validate_protected_effect_request(
+    agent_run_request: &AgentRunRequest,
+    support: &ContractSupport,
+    request: &ProtectedEffectRequest,
+) -> Result<String, ContractError> {
+    let expected_agent_run_digest = validate_request(agent_run_request, support)?;
+    if request.schema_version != PROTECTED_EFFECT_REQUEST_SCHEMA {
+        return Err(ContractError::new(
+            ContractErrorCode::UnsupportedSchema,
+            "schema_version",
+            format!(
+                "unsupported Protected Effect Request schema: {}",
+                request.schema_version
+            ),
+        ));
+    }
+    validate_non_empty(&request.effect_id, "effect_id")?;
+    if request.effect_sequence == 0 {
+        return Err(invalid_contract(
+            "effect_sequence",
+            "effect sequence must start at 1",
+        ));
+    }
+    validate_safe_integer(request.effect_sequence, "effect_sequence")?;
+    validate_non_empty(&request.run_id, "run_id")?;
+    if request.run_id != agent_run_request.run_id {
+        return Err(parent_mismatch("run_id"));
+    }
+    validate_digest(
+        &request.agent_run_request_digest,
+        "agent_run_request_digest",
+    )?;
+    if request.agent_run_request_digest != expected_agent_run_digest {
+        return Err(parent_mismatch("agent_run_request_digest"));
+    }
+
+    validate_subject(request)?;
+    validate_operation(request)?;
+    validate_capability(request)?;
+    if request.capability != agent_run_request.requested_capability {
+        return Err(parent_mismatch("capability"));
+    }
+    if let Some(tool_schema_digest) = &request.tool_schema_digest {
+        validate_digest(tool_schema_digest, "tool_schema_digest")?;
+    }
+    validate_digest(&request.input_digest, "input_digest")?;
+    validate_metadata(request)?;
+    validate_scopes(request)?;
+
+    if request.policies != agent_run_request.policies {
+        return Err(parent_mismatch("policies"));
+    }
+    validate_approvals(request)?;
+
+    validate_digest(&request.resource_budget_digest, "resource_budget_digest")?;
+    let expected_budget_digest =
+        canonical_resource_budget_digest(&agent_run_request.resource_budget)?;
+    if request.resource_budget_digest != expected_budget_digest {
+        return Err(parent_mismatch("resource_budget_digest"));
+    }
+
+    validate_non_empty(&request.sandbox_profile.name, "sandbox_profile.name")?;
+    validate_non_empty(&request.sandbox_profile.version, "sandbox_profile.version")?;
+    validate_digest(&request.sandbox_profile.digest, "sandbox_profile.digest")?;
+    validate_non_empty(&request.idempotency_key, "idempotency_key")?;
+
+    canonical_protected_effect_request_bytes(request).map(|bytes| sha256_digest(&bytes))
+}
+
+fn validate_subject(request: &ProtectedEffectRequest) -> Result<(), ContractError> {
+    validate_non_empty(&request.subject.locator, "subject.locator")?;
+    validate_digest(&request.subject.digest, "subject.digest")
+}
+
+fn validate_operation(request: &ProtectedEffectRequest) -> Result<(), ContractError> {
+    validate_non_empty(&request.normalized_operation, "normalized_operation")?;
+    let Some((family, _)) = request.normalized_operation.split_once('.') else {
+        return Err(invalid_contract(
+            "normalized_operation",
+            "normalized operation must contain a family prefix and operation name",
+        ));
+    };
+    if family != request.operation_family.as_str()
+        || !request
+            .normalized_operation
+            .split('.')
+            .all(valid_normalized_segment)
+    {
+        return Err(invalid_contract(
+            "normalized_operation",
+            "normalized operation must use lower-snake segments prefixed by its operation family",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_capability(request: &ProtectedEffectRequest) -> Result<(), ContractError> {
+    validate_non_empty(&request.capability.name, "capability.name")?;
+    validate_non_empty(&request.capability.version, "capability.version")?;
+    validate_digest(&request.capability.digest, "capability.digest")
+}
+
+fn validate_metadata(request: &ProtectedEffectRequest) -> Result<(), ContractError> {
+    if request.input_metadata.len() > MAX_METADATA_ENTRIES {
+        return Err(invalid_contract(
+            "input_metadata",
+            format!("input metadata is limited to {MAX_METADATA_ENTRIES} entries"),
+        ));
+    }
+    let mut names = BTreeSet::new();
+    for (index, entry) in request.input_metadata.iter().enumerate() {
+        let path = format!("input_metadata[{index}]");
+        validate_bounded_text(
+            &entry.name,
+            &format!("{path}.name"),
+            MAX_METADATA_NAME_CHARS,
+        )?;
+        if !names.insert(entry.name.as_str()) {
+            return Err(invalid_contract(
+                format!("{path}.name"),
+                "metadata names must be unique",
+            ));
+        }
+        validate_bounded_text(
+            &entry.value,
+            &format!("{path}.value"),
+            MAX_METADATA_VALUE_CHARS,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_scopes(request: &ProtectedEffectRequest) -> Result<(), ContractError> {
+    if request.requested_scopes.is_empty() {
+        return Err(invalid_contract(
+            "requested_scopes",
+            "at least one requested scope is required",
+        ));
+    }
+    for (index, scope) in request.requested_scopes.iter().enumerate() {
+        let path = format!("requested_scopes[{index}]");
+        match scope {
+            RequestedScope::Filesystem { root, access, .. } => {
+                validate_non_empty(root, &format!("{path}.root"))?;
+                if access.is_empty() {
+                    return Err(invalid_contract(
+                        format!("{path}.access"),
+                        "filesystem scope requires at least one access class",
+                    ));
+                }
+                let mut classes = BTreeSet::new();
+                for class in access {
+                    if !classes.insert(class) {
+                        return Err(invalid_contract(
+                            format!("{path}.access"),
+                            "filesystem access classes must be unique",
+                        ));
+                    }
+                }
+            }
+            RequestedScope::Process {
+                executable,
+                working_directory,
+            } => {
+                validate_non_empty(executable, &format!("{path}.executable"))?;
+                validate_non_empty(working_directory, &format!("{path}.working_directory"))?;
+            }
+            RequestedScope::Network { host, port, .. } => {
+                validate_non_empty(host, &format!("{path}.host"))?;
+                if host.contains("://") || host.chars().any(char::is_whitespace) {
+                    return Err(invalid_contract(
+                        format!("{path}.host"),
+                        "network host must not contain a scheme or whitespace",
+                    ));
+                }
+                if *port == 0 {
+                    return Err(invalid_contract(
+                        format!("{path}.port"),
+                        "network port must be between 1 and 65535",
+                    ));
+                }
+            }
+            RequestedScope::ExternalService {
+                service,
+                operation,
+                resource,
+            } => {
+                validate_non_empty(service, &format!("{path}.service"))?;
+                validate_non_empty(operation, &format!("{path}.operation"))?;
+                validate_non_empty(resource, &format!("{path}.resource"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_approvals(request: &ProtectedEffectRequest) -> Result<(), ContractError> {
+    let mut approval_ids = BTreeSet::new();
+    for (index, approval) in request.approval_context.iter().enumerate() {
+        let path = format!("approval_context[{index}]");
+        validate_non_empty(&approval.approval_id, &format!("{path}.approval_id"))?;
+        if !approval_ids.insert(approval.approval_id.as_str()) {
+            return Err(invalid_contract(
+                format!("{path}.approval_id"),
+                "approval IDs must be unique",
+            ));
+        }
+        validate_non_empty(&approval.actor_id, &format!("{path}.actor_id"))?;
+        validate_non_empty(&approval.scope, &format!("{path}.scope"))?;
+        validate_digest(&approval.subject_digest, &format!("{path}.subject_digest"))?;
+        validate_evidence(&approval.evidence, &format!("{path}.evidence"))?;
+        if approval.evidence.evidence_type != EvidenceType::Approval {
+            return Err(invalid_contract(
+                format!("{path}.evidence.evidence_type"),
+                "approval context must reference approval evidence",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_bounded_text(
+    value: &str,
+    path: &str,
+    maximum_chars: usize,
+) -> Result<(), ContractError> {
+    validate_non_empty(value, path)?;
+    if value.chars().count() > maximum_chars {
+        return Err(invalid_contract(
+            path,
+            format!("value must not exceed {maximum_chars} characters"),
+        ));
+    }
+    Ok(())
+}
+
+fn valid_normalized_segment(value: &str) -> bool {
+    let mut characters = value.chars();
+    characters
+        .next()
+        .is_some_and(|first| first.is_ascii_lowercase())
+        && characters.all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+        })
+}
+
+fn parent_mismatch(path: &str) -> ContractError {
+    ContractError::new(
+        ContractErrorCode::RequestMismatch,
+        path,
+        "Protected Effect Request does not match the validated Agent Run Request",
+    )
+}
+
+fn invalid_contract(path: impl Into<String>, message: impl Into<String>) -> ContractError {
+    ContractError::new(ContractErrorCode::InvalidContract, path, message)
+}

--- a/src/contracts/protected_effect/validation.rs
+++ b/src/contracts/protected_effect/validation.rs
@@ -238,6 +238,12 @@ fn validate_approvals(request: &ProtectedEffectRequest) -> Result<(), ContractEr
         validate_non_empty(&approval.actor_id, &format!("{path}.actor_id"))?;
         validate_non_empty(&approval.scope, &format!("{path}.scope"))?;
         validate_digest(&approval.subject_digest, &format!("{path}.subject_digest"))?;
+        if approval.subject_digest != request.subject.digest {
+            return Err(invalid_contract(
+                format!("{path}.subject_digest"),
+                "approval evidence must bind the Protected Effect Request subject",
+            ));
+        }
         validate_evidence(&approval.evidence, &format!("{path}.evidence"))?;
         if approval.evidence.evidence_type != EvidenceType::Approval {
             return Err(invalid_contract(

--- a/src/contracts/schema.rs
+++ b/src/contracts/schema.rs
@@ -2,9 +2,12 @@ use schemars::{Schema, schema_for};
 use serde_json::Value;
 
 use super::model::{AgentRunRequest, TerminalRunReceipt};
+use super::protected_effect::{ProtectedEffectRequest, ProtectedEffectResult};
 
 const REQUEST_SCHEMA_ID: &str = "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/agent-run/v0.1.0/agent-run-request.schema.json";
 const RECEIPT_SCHEMA_ID: &str = "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json";
+const EFFECT_REQUEST_SCHEMA_ID: &str = "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/protected-effect/v0.1.0/protected-effect-request.schema.json";
+const EFFECT_RESULT_SCHEMA_ID: &str = "https://raw.githubusercontent.com/nnennandukwe/governed-agent-autonomy-patterns/main/schemas/protected-effect/v0.1.0/protected-effect-result.schema.json";
 
 /// Generate the Draft 2020-12 Agent Run Request schema from the Rust types.
 pub fn agent_run_request_schema() -> Value {
@@ -21,6 +24,24 @@ pub fn terminal_run_receipt_schema() -> Value {
         schema_for!(TerminalRunReceipt),
         RECEIPT_SCHEMA_ID,
         "GAAP Terminal Run Receipt 0.1.0",
+    )
+}
+
+/// Generate the Draft 2020-12 Protected Effect Request schema from the Rust type.
+pub fn protected_effect_request_schema() -> Value {
+    document(
+        schema_for!(ProtectedEffectRequest),
+        EFFECT_REQUEST_SCHEMA_ID,
+        "GAAP Protected Effect Request 0.1.0",
+    )
+}
+
+/// Generate the Draft 2020-12 Protected Effect Result schema from the Rust type.
+pub fn protected_effect_result_schema() -> Value {
+    document(
+        schema_for!(ProtectedEffectResult),
+        EFFECT_RESULT_SCHEMA_ID,
+        "GAAP Protected Effect Result 0.1.0",
     )
 }
 

--- a/src/contracts/validation.rs
+++ b/src/contracts/validation.rs
@@ -28,6 +28,7 @@ pub enum ContractErrorCode {
     StaleVerification,
     RequestMismatch,
     ReceiptTampering,
+    ResultTampering,
 }
 
 /// Contract validation failure with a stable code and document path.

--- a/tests/protected_effect_contracts.rs
+++ b/tests/protected_effect_contracts.rs
@@ -1,12 +1,17 @@
 use gaap::contracts::{
     AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, ApprovalReference, CapabilityIdentity,
-    ContractErrorCode, ContractSupport, EffectClass, EvidenceReference, EvidenceType,
-    FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
-    PROTECTED_EFFECT_REQUEST_SCHEMA, PolicyIdentity, ProtectedEffectRequest, Repeatability,
+    ContractErrorCode, ContractSupport, EffectClass, EffectEvidenceReference, EffectEvidenceType,
+    EffectExecutionStatus, EffectExit, EffectUsage, EvidenceReference, EvidenceType,
+    ExecutorIdentity, FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
+    PROTECTED_EFFECT_REQUEST_SCHEMA, PROTECTED_EFFECT_RESULT_SCHEMA, PolicyIdentity,
+    ProtectedEffectDecision, ProtectedEffectRequest, ProtectedEffectResultBody, Repeatability,
     RequestedScope, ResourceBudget, SandboxProfileIdentity, Subject, SubjectKind, TaskSpec,
     VerificationIndependence, VerificationRequirement, canonical_protected_effect_request_bytes,
-    parse_protected_effect_request_json, validate_protected_effect_request,
+    parse_protected_effect_request_json, parse_protected_effect_result_json,
+    seal_protected_effect_result, validate_protected_effect_request,
+    validate_protected_effect_result_body, verify_protected_effect_result,
 };
+use gaap::{Decision, Gate, Outcome};
 use sha2::{Digest, Sha256};
 
 type RequestMutation = Box<dyn Fn(&mut ProtectedEffectRequest)>;
@@ -587,6 +592,831 @@ fn raw_effect_request_rejects_unknown_fields_families_and_repeatability() {
             &serde_json::to_vec(&changed).expect("request should serialize"),
         )
         .expect_err("unknown contract value must fail");
+        assert_eq!(error.code(), ContractErrorCode::InvalidJson);
+    }
+}
+
+fn effect_evidence(evidence_type: EffectEvidenceType, byte: char) -> EffectEvidenceReference {
+    EffectEvidenceReference {
+        evidence_type,
+        digest: digest(byte),
+        locator: None,
+    }
+}
+
+fn decision(
+    outcome: Outcome,
+    effect_request_digest: &str,
+    subject_digest: &str,
+) -> ProtectedEffectDecision {
+    ProtectedEffectDecision {
+        decision_id: "decision-001".to_owned(),
+        gate: Gate::Permission,
+        effect_request_digest: effect_request_digest.to_owned(),
+        subject_digest: subject_digest.to_owned(),
+        decision: Decision {
+            outcome,
+            code: "permission.policy_allowed".to_owned(),
+            effects: vec![],
+        },
+    }
+}
+
+fn usage() -> EffectUsage {
+    EffectUsage {
+        cost_micros: 10,
+        elapsed_ms: 25,
+        model_tokens: 0,
+        tool_calls: 1,
+    }
+}
+
+fn zero_usage() -> EffectUsage {
+    EffectUsage {
+        cost_micros: 0,
+        elapsed_ms: 0,
+        model_tokens: 0,
+        tool_calls: 0,
+    }
+}
+
+fn executed_result_body(
+    request: &ProtectedEffectRequest,
+    effect_request_digest: &str,
+) -> ProtectedEffectResultBody {
+    let mut post_subject = request.subject.clone();
+    post_subject.digest = digest('9');
+
+    ProtectedEffectResultBody {
+        schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+        effect_id: request.effect_id.clone(),
+        effect_sequence: request.effect_sequence,
+        run_id: request.run_id.clone(),
+        agent_run_request_digest: request.agent_run_request_digest.clone(),
+        effect_request_digest: effect_request_digest.to_owned(),
+        observed_pre_effect_subject: request.subject.clone(),
+        observed_capability: request.capability.clone(),
+        observed_tool_schema_digest: request.tool_schema_digest.clone(),
+        decision: decision(
+            Outcome::Allow,
+            effect_request_digest,
+            &request.subject.digest,
+        ),
+        execution_status: EffectExecutionStatus::Executed,
+        observed_post_effect_subject: Some(post_subject),
+        exit: Some(EffectExit::Code { code: 0 }),
+        usage: usage(),
+        executor: Some(ExecutorIdentity {
+            name: "local-runner".to_owned(),
+            version: "0.1.0".to_owned(),
+            digest: digest('6'),
+        }),
+        sandbox_profile: Some(request.sandbox_profile.clone()),
+        reason: None,
+        evidence: vec![
+            effect_evidence(EffectEvidenceType::Exit, '0'),
+            effect_evidence(EffectEvidenceType::Output, '1'),
+            effect_evidence(EffectEvidenceType::Artifact, '2'),
+            effect_evidence(EffectEvidenceType::Mutation, '3'),
+            effect_evidence(EffectEvidenceType::Usage, '4'),
+            effect_evidence(EffectEvidenceType::Executor, '5'),
+            effect_evidence(EffectEvidenceType::Sandbox, '6'),
+            effect_evidence(EffectEvidenceType::SubjectObservation, '7'),
+        ],
+    }
+}
+
+fn non_execution_result_body(
+    request: &ProtectedEffectRequest,
+    effect_request_digest: &str,
+    status: EffectExecutionStatus,
+    outcome: Outcome,
+) -> ProtectedEffectResultBody {
+    let mut body = executed_result_body(request, effect_request_digest);
+    body.decision = decision(outcome, effect_request_digest, &request.subject.digest);
+    body.execution_status = status;
+    body.observed_post_effect_subject = None;
+    body.exit = None;
+    body.usage = zero_usage();
+    body.executor = None;
+    body.sandbox_profile = None;
+    body.reason = Some("authority was not granted".to_owned());
+    body.evidence.clear();
+    body
+}
+
+#[test]
+fn executed_result_is_sealed_and_verified_with_a_stable_digest() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+    let body = executed_result_body(&request, &request_digest);
+
+    let result = seal_protected_effect_result(&agent_request, &support, &request, body)
+        .expect("executed result should seal");
+    verify_protected_effect_result(&agent_request, &support, &request, &result)
+        .expect("sealed result should verify");
+
+    assert_eq!(
+        result.result_digest,
+        "sha256:f3952c57da5ce2ec5327dc20b625b1f8363f271ac0cedb618e736bccc871102a"
+    );
+}
+
+#[test]
+fn result_rejects_unsupported_versions_unsafe_sequences_and_malformed_digests() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    for (body, expected_code, expected_path) in [
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.schema_version = "gaap.protected-effect-result/0.2.0".to_owned();
+                body
+            },
+            ContractErrorCode::UnsupportedSchema,
+            "body.schema_version",
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.effect_sequence = 9_007_199_254_740_992;
+                body
+            },
+            ContractErrorCode::InvalidContract,
+            "body.effect_sequence",
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.observed_tool_schema_digest = Some("sha256:1234".to_owned());
+                body
+            },
+            ContractErrorCode::InvalidDigest,
+            "body.observed_tool_schema_digest",
+        ),
+    ] {
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("invalid result version, bound, or digest must fail");
+        assert_eq!(error.code(), expected_code);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn result_identity_sequence_and_request_digest_mismatches_fail_closed() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    for (body, expected_path) in [
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.effect_id = "effect-other".to_owned();
+                body
+            },
+            "body.effect_id",
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.effect_sequence = 2;
+                body
+            },
+            "body.effect_sequence",
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.agent_run_request_digest = digest('8');
+                body
+            },
+            "body.agent_run_request_digest",
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.effect_request_digest = digest('8');
+                body
+            },
+            "body.effect_request_digest",
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.decision.effect_request_digest = digest('8');
+                body
+            },
+            "body.decision.effect_request_digest",
+        ),
+    ] {
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("result identity mismatch must fail closed");
+        assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn decision_outcomes_and_execution_statuses_follow_the_authority_matrix() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    for outcome in [Outcome::Ask, Outcome::Block] {
+        let mut body = executed_result_body(&request, &request_digest);
+        body.decision = decision(outcome, &request_digest, &request.subject.digest);
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("ask or block must never coexist with execution");
+        assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+        assert_eq!(error.path(), "body.decision.decision.outcome");
+    }
+
+    for (status, outcome) in [
+        (EffectExecutionStatus::AwaitingAuthority, Outcome::Ask),
+        (EffectExecutionStatus::Denied, Outcome::Block),
+    ] {
+        let body = non_execution_result_body(&request, &request_digest, status, outcome);
+        validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+            .expect("non-execution authority result should validate");
+    }
+}
+
+#[test]
+fn attempted_results_require_observed_execution_identities_and_evidence() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    for (body, expected_path, expected_code) in [
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.executor = None;
+                body
+            },
+            "body.executor",
+            ContractErrorCode::InvalidContract,
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.sandbox_profile = None;
+                body
+            },
+            "body.sandbox_profile",
+            ContractErrorCode::InvalidContract,
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.evidence
+                    .retain(|item| item.evidence_type != EffectEvidenceType::Usage);
+                body
+            },
+            "body.evidence",
+            ContractErrorCode::InvalidContract,
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.evidence
+                    .retain(|item| item.evidence_type != EffectEvidenceType::SubjectObservation);
+                body
+            },
+            "body.evidence",
+            ContractErrorCode::InvalidContract,
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.observed_post_effect_subject = None;
+                body
+            },
+            "body.observed_post_effect_subject",
+            ContractErrorCode::InvalidContract,
+        ),
+        (
+            {
+                let mut body = executed_result_body(&request, &request_digest);
+                body.sandbox_profile
+                    .as_mut()
+                    .expect("sandbox exists")
+                    .digest = digest('8');
+                body
+            },
+            "body.sandbox_profile",
+            ContractErrorCode::RequestMismatch,
+        ),
+    ] {
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("attempted result missing a required identity or evidence must fail");
+        assert_eq!(error.code(), expected_code);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn result_reason_presence_matches_execution_status() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    let mut executed = executed_result_body(&request, &request_digest);
+    executed.reason = Some("unexpected reason".to_owned());
+    let error =
+        validate_protected_effect_result_body(&agent_request, &support, &request, &executed)
+            .expect_err("executed result must not contain a reason");
+    assert_eq!(error.path(), "body.reason");
+
+    for (status, outcome) in [
+        (EffectExecutionStatus::AwaitingAuthority, Outcome::Ask),
+        (EffectExecutionStatus::Denied, Outcome::Block),
+    ] {
+        let mut body = non_execution_result_body(&request, &request_digest, status, outcome);
+        body.reason = None;
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("non-execution result requires a reason");
+        assert_eq!(error.path(), "body.reason");
+    }
+
+    for status in [
+        EffectExecutionStatus::Failed,
+        EffectExecutionStatus::Interrupted,
+        EffectExecutionStatus::UnknownOutcome,
+    ] {
+        let mut body = executed_result_body(&request, &request_digest);
+        body.execution_status = status;
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("attempted non-success result requires a reason");
+        assert_eq!(error.path(), "body.reason");
+    }
+}
+
+#[test]
+fn awaiting_and_denied_results_reject_execution_derived_fields() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    for (body, expected_path) in [
+        (
+            {
+                let mut body = non_execution_result_body(
+                    &request,
+                    &request_digest,
+                    EffectExecutionStatus::AwaitingAuthority,
+                    Outcome::Ask,
+                );
+                body.usage.tool_calls = 1;
+                body
+            },
+            "body.usage",
+        ),
+        (
+            {
+                let mut body = non_execution_result_body(
+                    &request,
+                    &request_digest,
+                    EffectExecutionStatus::Denied,
+                    Outcome::Block,
+                );
+                body.executor = Some(ExecutorIdentity {
+                    name: "must-not-run".to_owned(),
+                    version: "0.1.0".to_owned(),
+                    digest: digest('8'),
+                });
+                body
+            },
+            "body.executor",
+        ),
+        (
+            {
+                let mut body = non_execution_result_body(
+                    &request,
+                    &request_digest,
+                    EffectExecutionStatus::Denied,
+                    Outcome::Block,
+                );
+                body.evidence = vec![effect_evidence(EffectEvidenceType::Output, '8')];
+                body
+            },
+            "body.evidence[0].evidence_type",
+        ),
+    ] {
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("non-execution result must not contain execution-derived state");
+        assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn attempted_failures_interruptions_and_unknown_outcomes_remain_distinct() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    for (status, required_evidence, conflicting_evidence) in [
+        (
+            EffectExecutionStatus::Failed,
+            EffectEvidenceType::Failure,
+            EffectEvidenceType::Interruption,
+        ),
+        (
+            EffectExecutionStatus::Interrupted,
+            EffectEvidenceType::Interruption,
+            EffectEvidenceType::Failure,
+        ),
+        (
+            EffectExecutionStatus::UnknownOutcome,
+            EffectEvidenceType::UnknownOutcome,
+            EffectEvidenceType::Failure,
+        ),
+    ] {
+        let mut body = executed_result_body(&request, &request_digest);
+        body.execution_status = status;
+        body.reason = Some(format!("effect ended as {status:?}"));
+        body.evidence.push(effect_evidence(required_evidence, '8'));
+        if status == EffectExecutionStatus::Interrupted {
+            body.exit = Some(EffectExit::Signal {
+                signal: "SIGTERM".to_owned(),
+            });
+        }
+        if status == EffectExecutionStatus::UnknownOutcome {
+            body.observed_post_effect_subject = None;
+            body.exit = None;
+            body.evidence.retain(|reference| {
+                matches!(
+                    reference.evidence_type,
+                    EffectEvidenceType::Usage
+                        | EffectEvidenceType::Executor
+                        | EffectEvidenceType::Sandbox
+                        | EffectEvidenceType::UnknownOutcome
+                )
+            });
+        }
+
+        validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+            .expect("attempt status with its distinct evidence should validate");
+
+        let mut contradictory = body.clone();
+        contradictory
+            .evidence
+            .push(effect_evidence(conflicting_evidence, '7'));
+        let error = validate_protected_effect_result_body(
+            &agent_request,
+            &support,
+            &request,
+            &contradictory,
+        )
+        .expect_err("attempt status with contradictory evidence must fail");
+        assert!(error.path().ends_with("evidence_type"));
+
+        body.evidence
+            .retain(|reference| reference.evidence_type != required_evidence);
+        let error =
+            validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+                .expect_err("attempt status without its distinguishing evidence must fail");
+        assert_eq!(error.path(), "body.evidence");
+    }
+}
+
+#[test]
+fn non_repeatable_request_can_record_an_unknown_outcome_without_becoming_failure() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let mut request = effect_request(&agent_request, &support);
+    request.repeatability = Repeatability::NonRepeatable;
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("non-repeatable effect request should validate");
+    let mut body = executed_result_body(&request, &request_digest);
+    body.execution_status = EffectExecutionStatus::UnknownOutcome;
+    body.observed_post_effect_subject = None;
+    body.exit = None;
+    body.reason = Some("executor disconnected before reconciliation".to_owned());
+    body.evidence.retain(|reference| {
+        matches!(
+            reference.evidence_type,
+            EffectEvidenceType::Usage | EffectEvidenceType::Executor | EffectEvidenceType::Sandbox
+        )
+    });
+    body.evidence
+        .push(effect_evidence(EffectEvidenceType::UnknownOutcome, '8'));
+
+    validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+        .expect("unknown outcome remains representable for a non-repeatable request");
+    assert_eq!(body.execution_status, EffectExecutionStatus::UnknownOutcome);
+}
+
+#[test]
+fn stale_subject_and_tool_schema_drift_are_valid_denials() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    let mut stale = non_execution_result_body(
+        &request,
+        &request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+    );
+    stale.observed_pre_effect_subject.digest = digest('8');
+    stale.decision.subject_digest = digest('8');
+    stale.reason = Some("protected_effect.stale_subject".to_owned());
+    stale.evidence = vec![effect_evidence(EffectEvidenceType::SubjectObservation, '8')];
+    validate_protected_effect_result_body(&agent_request, &support, &request, &stale)
+        .expect("stale subject should be preserved as a denied result");
+
+    let mut drift = non_execution_result_body(
+        &request,
+        &request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+    );
+    drift.observed_tool_schema_digest = Some(digest('8'));
+    drift.reason = Some("protected_effect.capability_schema_drift".to_owned());
+    drift.evidence = vec![effect_evidence(EffectEvidenceType::CapabilitySchema, '8')];
+    validate_protected_effect_result_body(&agent_request, &support, &request, &drift)
+        .expect("tool-schema drift should be preserved as a denied result");
+}
+
+#[test]
+fn drift_mismatches_cannot_be_disguised_as_executed_or_generic_denials() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    let mut executed = executed_result_body(&request, &request_digest);
+    executed.observed_pre_effect_subject.digest = digest('8');
+    executed.decision.subject_digest = digest('8');
+    let error =
+        validate_protected_effect_result_body(&agent_request, &support, &request, &executed)
+            .expect_err("executed result with a stale subject must fail closed");
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+    assert_eq!(error.path(), "body.observed_pre_effect_subject");
+
+    let mut denied = non_execution_result_body(
+        &request,
+        &request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+    );
+    denied.observed_tool_schema_digest = Some(digest('8'));
+    let error = validate_protected_effect_result_body(&agent_request, &support, &request, &denied)
+        .expect_err("schema drift must carry a precise denial reason");
+    assert_eq!(error.path(), "body.reason");
+
+    let mut invented_drift = non_execution_result_body(
+        &request,
+        &request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+    );
+    invented_drift.reason = Some("protected_effect.stale_subject".to_owned());
+    invented_drift.evidence = vec![effect_evidence(EffectEvidenceType::SubjectObservation, '8')];
+    let error =
+        validate_protected_effect_result_body(&agent_request, &support, &request, &invented_drift)
+            .expect_err("reserved drift reason requires an observed identity difference");
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "body.reason");
+
+    let mut capability_mismatch = non_execution_result_body(
+        &request,
+        &request_digest,
+        EffectExecutionStatus::Denied,
+        Outcome::Block,
+    );
+    capability_mismatch.observed_capability.digest = digest('8');
+    capability_mismatch.reason = Some("protected_effect.capability_schema_drift".to_owned());
+    capability_mismatch.evidence = vec![effect_evidence(EffectEvidenceType::CapabilitySchema, '8')];
+    let error = validate_protected_effect_result_body(
+        &agent_request,
+        &support,
+        &request,
+        &capability_mismatch,
+    )
+    .expect_err("a different capability identity is not tool-schema drift");
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+    assert_eq!(error.path(), "body.observed_capability");
+}
+
+#[test]
+fn observation_and_mutation_results_enforce_subject_and_evidence_rules() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+
+    let mut observation_request = effect_request(&agent_request, &support);
+    observation_request.expected_effect_class = EffectClass::Observation;
+    let observation_digest =
+        validate_protected_effect_request(&agent_request, &support, &observation_request)
+            .expect("observation request should validate");
+    let mut observation = executed_result_body(&observation_request, &observation_digest);
+    observation.observed_post_effect_subject = Some(observation_request.subject.clone());
+    observation.evidence.retain(|reference| {
+        !matches!(
+            reference.evidence_type,
+            EffectEvidenceType::Mutation | EffectEvidenceType::Artifact
+        )
+    });
+    validate_protected_effect_result_body(
+        &agent_request,
+        &support,
+        &observation_request,
+        &observation,
+    )
+    .expect("observation preserving its subject should validate");
+
+    observation
+        .observed_post_effect_subject
+        .as_mut()
+        .expect("post subject exists")
+        .locator = "https://mirror.example.invalid/repository".to_owned();
+    validate_protected_effect_result_body(
+        &agent_request,
+        &support,
+        &observation_request,
+        &observation,
+    )
+    .expect("observation preservation is defined by the subject digest");
+
+    observation
+        .observed_post_effect_subject
+        .as_mut()
+        .expect("post subject exists")
+        .digest = digest('8');
+    let error = validate_protected_effect_result_body(
+        &agent_request,
+        &support,
+        &observation_request,
+        &observation,
+    )
+    .expect_err("observation must preserve its subject");
+    assert_eq!(error.path(), "body.observed_post_effect_subject");
+
+    let mutation_request = effect_request(&agent_request, &support);
+    let mutation_digest =
+        validate_protected_effect_request(&agent_request, &support, &mutation_request)
+            .expect("mutation request should validate");
+    let mut mutation = executed_result_body(&mutation_request, &mutation_digest);
+    mutation.evidence.retain(|reference| {
+        !matches!(
+            reference.evidence_type,
+            EffectEvidenceType::Mutation | EffectEvidenceType::Artifact
+        )
+    });
+    let error = validate_protected_effect_result_body(
+        &agent_request,
+        &support,
+        &mutation_request,
+        &mutation,
+    )
+    .expect_err("mutation must carry mutation and artifact evidence");
+    assert_eq!(error.path(), "body.evidence");
+}
+
+#[test]
+fn known_process_results_require_typed_exit_status_and_exit_evidence() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    let mut body = executed_result_body(&request, &request_digest);
+    body.exit = None;
+    let error = validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+        .expect_err("known process execution requires exit status");
+    assert_eq!(error.path(), "body.exit");
+
+    body = executed_result_body(&request, &request_digest);
+    body.evidence
+        .retain(|reference| reference.evidence_type != EffectEvidenceType::Exit);
+    let error = validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+        .expect_err("known process execution requires exit evidence");
+    assert_eq!(error.path(), "body.evidence");
+}
+
+#[test]
+fn result_tampering_and_cross_run_replay_fail_closed() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+    let result = seal_protected_effect_result(
+        &agent_request,
+        &support,
+        &request,
+        executed_result_body(&request, &request_digest),
+    )
+    .expect("executed result should seal");
+
+    let mut tampered = result.clone();
+    tampered.body.reason = Some("rewritten after sealing".to_owned());
+    let error = verify_protected_effect_result(&agent_request, &support, &request, &tampered)
+        .expect_err("body tampering must fail");
+    assert_eq!(error.code(), ContractErrorCode::ResultTampering);
+    assert_eq!(error.path(), "result_digest");
+
+    let mut malformed = result.clone();
+    malformed.result_digest = "sha256:not-a-digest".to_owned();
+    let error = verify_protected_effect_result(&agent_request, &support, &request, &malformed)
+        .expect_err("malformed result digest must fail as result tampering");
+    assert_eq!(error.code(), ContractErrorCode::ResultTampering);
+    assert_eq!(error.path(), "result_digest");
+
+    let other_agent_request = agent_run_request("run-002");
+    let other_request = effect_request(&other_agent_request, &support);
+    let error =
+        verify_protected_effect_result(&other_agent_request, &support, &other_request, &result)
+            .expect_err("cross-run replay must fail");
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+
+    let mut other_request = request.clone();
+    other_request.effect_id = "effect-002".to_owned();
+    other_request.input_digest = digest('8');
+    other_request.idempotency_key = "run-001/effect-002".to_owned();
+    let error = verify_protected_effect_result(&agent_request, &support, &other_request, &result)
+        .expect_err("same-run cross-request replay must fail");
+    assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+}
+
+#[test]
+fn raw_effect_result_rejects_unknown_statuses_evidence_and_fields() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+    let result = seal_protected_effect_result(
+        &agent_request,
+        &support,
+        &request,
+        executed_result_body(&request, &request_digest),
+    )
+    .expect("executed result should seal");
+    let value = serde_json::to_value(result).expect("result should serialize");
+
+    for changed in [
+        {
+            let mut changed = value.clone();
+            changed["body"]["execution_status"] = serde_json::json!("retried");
+            changed
+        },
+        {
+            let mut changed = value.clone();
+            changed["body"]["evidence"][0]["evidence_type"] = serde_json::json!("provider_trace");
+            changed
+        },
+        {
+            let mut changed = value.clone();
+            changed["body"]["exit"] = serde_json::json!({
+                "exit_type": "provider_status",
+                "code": 0
+            });
+            changed
+        },
+        {
+            let mut changed = value;
+            changed["body"]["raw_output"] = serde_json::json!("secret");
+            changed
+        },
+    ] {
+        let error = parse_protected_effect_result_json(
+            &serde_json::to_vec(&changed).expect("result should serialize"),
+        )
+        .expect_err("unknown result values and fields must fail");
         assert_eq!(error.code(), ContractErrorCode::InvalidJson);
     }
 }

--- a/tests/protected_effect_contracts.rs
+++ b/tests/protected_effect_contracts.rs
@@ -1,0 +1,592 @@
+use gaap::contracts::{
+    AGENT_RUN_REQUEST_SCHEMA, AgentRunRequest, ApprovalReference, CapabilityIdentity,
+    ContractErrorCode, ContractSupport, EffectClass, EvidenceReference, EvidenceType,
+    FilesystemAccess, InputMetadataEntry, NetworkProtocol, OperationFamily,
+    PROTECTED_EFFECT_REQUEST_SCHEMA, PolicyIdentity, ProtectedEffectRequest, Repeatability,
+    RequestedScope, ResourceBudget, SandboxProfileIdentity, Subject, SubjectKind, TaskSpec,
+    VerificationIndependence, VerificationRequirement, canonical_protected_effect_request_bytes,
+    parse_protected_effect_request_json, validate_protected_effect_request,
+};
+use sha2::{Digest, Sha256};
+
+type RequestMutation = Box<dyn Fn(&mut ProtectedEffectRequest)>;
+
+fn digest(byte: char) -> String {
+    format!("sha256:{}", byte.to_string().repeat(64))
+}
+
+fn policy() -> PolicyIdentity {
+    PolicyIdentity {
+        name: "gaap.run-coordinator".to_owned(),
+        version: "0.1.0".to_owned(),
+        digest: digest('b'),
+    }
+}
+
+fn evidence(evidence_type: EvidenceType, byte: char) -> EvidenceReference {
+    EvidenceReference {
+        evidence_type,
+        digest: digest(byte),
+        locator: None,
+    }
+}
+
+fn approval() -> ApprovalReference {
+    ApprovalReference {
+        approval_id: "approval-effect-001".to_owned(),
+        actor_id: "maintainer-001".to_owned(),
+        scope: "protected_effect".to_owned(),
+        subject_digest: digest('a'),
+        evidence: evidence(EvidenceType::Approval, 'e'),
+    }
+}
+
+fn agent_run_request(run_id: &str) -> AgentRunRequest {
+    AgentRunRequest {
+        schema_version: AGENT_RUN_REQUEST_SCHEMA.to_owned(),
+        request_id: format!("request-{run_id}"),
+        run_id: run_id.to_owned(),
+        subject: Subject {
+            kind: SubjectKind::Repository,
+            locator: "https://example.invalid/repository".to_owned(),
+            digest: digest('a'),
+        },
+        requested_capability: CapabilityIdentity {
+            name: "change-code".to_owned(),
+            version: "1".to_owned(),
+            digest: digest('c'),
+        },
+        task: TaskSpec {
+            instructions: "Implement the approved change.".to_owned(),
+            constraints: vec!["Do not publish a release.".to_owned()],
+        },
+        policies: vec![policy()],
+        resource_budget: ResourceBudget {
+            max_cost_micros: 1_000_000,
+            max_elapsed_ms: 60_000,
+            max_model_tokens: 100_000,
+            max_tool_calls: 100,
+        },
+        approval_context: vec![],
+        required_verification: VerificationRequirement {
+            independence: VerificationIndependence::DifferentActor,
+            evidence_types: vec![EvidenceType::CommandOutput, EvidenceType::Artifact],
+        },
+    }
+}
+
+fn effect_request(
+    agent_request: &AgentRunRequest,
+    support: &ContractSupport,
+) -> ProtectedEffectRequest {
+    let agent_run_request_digest = gaap::contracts::validate_request(agent_request, support)
+        .expect("Agent Run Request should validate");
+    let resource_budget_digest =
+        gaap::contracts::canonical_resource_budget_digest(&agent_request.resource_budget)
+            .expect("resource budget should canonicalize");
+
+    ProtectedEffectRequest {
+        schema_version: PROTECTED_EFFECT_REQUEST_SCHEMA.to_owned(),
+        effect_id: "effect-001".to_owned(),
+        effect_sequence: 1,
+        run_id: agent_request.run_id.clone(),
+        agent_run_request_digest,
+        subject: agent_request.subject.clone(),
+        operation_family: OperationFamily::Process,
+        normalized_operation: "process.spawn".to_owned(),
+        capability: agent_request.requested_capability.clone(),
+        tool_schema_digest: Some(digest('d')),
+        input_digest: digest('1'),
+        input_metadata: vec![
+            InputMetadataEntry {
+                name: "argument_count".to_owned(),
+                value: "2".to_owned(),
+            },
+            InputMetadataEntry {
+                name: "content_type".to_owned(),
+                value: "application/json".to_owned(),
+            },
+        ],
+        requested_scopes: vec![
+            RequestedScope::Process {
+                executable: "/usr/bin/cargo".to_owned(),
+                working_directory: "/workspace".to_owned(),
+            },
+            RequestedScope::Filesystem {
+                root: "/workspace".to_owned(),
+                access: vec![FilesystemAccess::Read, FilesystemAccess::Modify],
+                recursive: true,
+            },
+            RequestedScope::Network {
+                protocol: NetworkProtocol::Https,
+                host: "crates.io".to_owned(),
+                port: 443,
+            },
+            RequestedScope::ExternalService {
+                service: "github".to_owned(),
+                operation: "pull_request.comment".to_owned(),
+                resource: "nnennandukwe/repository#22".to_owned(),
+            },
+        ],
+        policies: agent_request.policies.clone(),
+        approval_context: vec![approval()],
+        resource_budget_digest,
+        sandbox_profile: SandboxProfileIdentity {
+            name: "local-process".to_owned(),
+            version: "0.1.0".to_owned(),
+            digest: digest('f'),
+        },
+        idempotency_key: "run-001/effect-001".to_owned(),
+        repeatability: Repeatability::Idempotent,
+        expected_effect_class: EffectClass::Mutation,
+    }
+}
+
+#[test]
+fn supported_effect_request_returns_a_stable_canonical_digest() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+
+    let first = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+    let second = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate deterministically");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first,
+        "sha256:f34fe9ac5723efa50583aed72d23bfb4b44ab339e484383bea7d86fbf1c4cf62"
+    );
+}
+
+#[test]
+fn every_request_enum_member_is_accepted() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+
+    let cases = vec![
+        (
+            OperationFamily::Filesystem,
+            "filesystem.write",
+            RequestedScope::Filesystem {
+                root: "/workspace".to_owned(),
+                access: vec![
+                    FilesystemAccess::Read,
+                    FilesystemAccess::Create,
+                    FilesystemAccess::Modify,
+                    FilesystemAccess::Delete,
+                ],
+                recursive: true,
+            },
+        ),
+        (
+            OperationFamily::Process,
+            "process.spawn",
+            RequestedScope::Process {
+                executable: "/usr/bin/cargo".to_owned(),
+                working_directory: "/workspace".to_owned(),
+            },
+        ),
+        (
+            OperationFamily::ExternalService,
+            "external_service.invoke",
+            RequestedScope::ExternalService {
+                service: "github".to_owned(),
+                operation: "pull_request.comment".to_owned(),
+                resource: "nnennandukwe/repository#22".to_owned(),
+            },
+        ),
+    ];
+
+    for (operation_family, normalized_operation, scope) in cases {
+        let mut request = effect_request(&agent_request, &support);
+        request.operation_family = operation_family;
+        request.normalized_operation = normalized_operation.to_owned();
+        request.requested_scopes = vec![scope];
+        validate_protected_effect_request(&agent_request, &support, &request)
+            .expect("each operation family and scope must validate");
+    }
+
+    for protocol in [
+        NetworkProtocol::Tcp,
+        NetworkProtocol::Udp,
+        NetworkProtocol::Http,
+        NetworkProtocol::Https,
+    ] {
+        let mut request = effect_request(&agent_request, &support);
+        request.operation_family = OperationFamily::Network;
+        request.normalized_operation = "network.connect".to_owned();
+        request.requested_scopes = vec![RequestedScope::Network {
+            protocol,
+            host: "example.invalid".to_owned(),
+            port: 443,
+        }];
+        validate_protected_effect_request(&agent_request, &support, &request)
+            .expect("each network protocol must validate");
+    }
+
+    for repeatability in [
+        Repeatability::Repeatable,
+        Repeatability::Idempotent,
+        Repeatability::NonRepeatable,
+    ] {
+        let mut request = effect_request(&agent_request, &support);
+        request.repeatability = repeatability;
+        validate_protected_effect_request(&agent_request, &support, &request)
+            .expect("each repeatability value must validate");
+    }
+
+    for effect_class in [EffectClass::Observation, EffectClass::Mutation] {
+        let mut request = effect_request(&agent_request, &support);
+        request.expected_effect_class = effect_class;
+        validate_protected_effect_request(&agent_request, &support, &request)
+            .expect("each effect class must validate");
+    }
+}
+
+#[test]
+fn effect_request_rejects_unsupported_versions_and_unsafe_sequences() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+
+    for (request, expected_code, expected_path) in [
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.schema_version = "gaap.protected-effect-request/0.2.0".to_owned();
+                request
+            },
+            ContractErrorCode::UnsupportedSchema,
+            "schema_version",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.effect_sequence = 0;
+                request
+            },
+            ContractErrorCode::InvalidContract,
+            "effect_sequence",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.effect_sequence = 9_007_199_254_740_992;
+                request
+            },
+            ContractErrorCode::InvalidContract,
+            "effect_sequence",
+        ),
+    ] {
+        let error = validate_protected_effect_request(&agent_request, &support, &request)
+            .expect_err("unsupported version or unsafe sequence must fail");
+        assert_eq!(error.code(), expected_code);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn effect_request_digest_changes_for_every_authority_bearing_input() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let original = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+
+    let mutations: Vec<RequestMutation> = vec![
+        Box::new(|value| value.input_digest = digest('2')),
+        Box::new(|value| value.tool_schema_digest = Some(digest('3'))),
+        Box::new(|value| value.subject.digest = digest('4')),
+        Box::new(|value| value.policies[0].digest = digest('5')),
+        Box::new(|value| value.approval_context[0].approval_id = "approval-002".to_owned()),
+        Box::new(|value| value.resource_budget_digest = digest('6')),
+        Box::new(|value| value.sandbox_profile.digest = digest('7')),
+    ];
+
+    for mutate in mutations {
+        let mut changed = request.clone();
+        mutate(&mut changed);
+        let changed_digest = canonical_protected_effect_request_bytes(&changed)
+            .map(|bytes| format!("sha256:{:x}", Sha256::digest(bytes)))
+            .expect("changed request should canonicalize");
+        assert_ne!(changed_digest, original);
+    }
+}
+
+#[test]
+fn effect_request_must_match_the_parent_run_capability_policy_and_budget() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+
+    for (request, expected_path) in [
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.run_id = "run-other".to_owned();
+                request
+            },
+            "run_id",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.capability.digest = digest('8');
+                request
+            },
+            "capability",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.policies[0].digest = digest('8');
+                request
+            },
+            "policies",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.resource_budget_digest = digest('8');
+                request
+            },
+            "resource_budget_digest",
+        ),
+    ] {
+        let error = validate_protected_effect_request(&agent_request, &support, &request)
+            .expect_err("parent mismatch must fail closed");
+        assert_eq!(error.code(), ContractErrorCode::RequestMismatch);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn malformed_effect_request_digests_fail_closed() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+
+    for (request, expected_path) in [
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.agent_run_request_digest = "sha256:not-a-digest".to_owned();
+                request
+            },
+            "agent_run_request_digest",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.tool_schema_digest = Some("SHA256:ABC".to_owned());
+                request
+            },
+            "tool_schema_digest",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.input_digest = "sha256:1234".to_owned();
+                request
+            },
+            "input_digest",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.sandbox_profile.digest = "sha256:1234".to_owned();
+                request
+            },
+            "sandbox_profile.digest",
+        ),
+    ] {
+        let error = validate_protected_effect_request(&agent_request, &support, &request)
+            .expect_err("malformed request digest must fail");
+        assert_eq!(error.code(), ContractErrorCode::InvalidDigest);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn metadata_is_bounded_and_names_are_unique() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let mut request = effect_request(&agent_request, &support);
+    request.input_metadata.push(InputMetadataEntry {
+        name: "content_type".to_owned(),
+        value: "text/plain".to_owned(),
+    });
+
+    let duplicate = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("duplicate metadata names must fail");
+    assert_eq!(duplicate.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(duplicate.path(), "input_metadata[2].name");
+
+    request = effect_request(&agent_request, &support);
+    request.input_metadata = (0..33)
+        .map(|index| InputMetadataEntry {
+            name: format!("key_{index}"),
+            value: "value".to_owned(),
+        })
+        .collect();
+    let too_many = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("too many metadata entries must fail");
+    assert_eq!(too_many.path(), "input_metadata");
+
+    request = effect_request(&agent_request, &support);
+    request.input_metadata[0].name = "n".repeat(65);
+    let long_name = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("long metadata name must fail");
+    assert_eq!(long_name.path(), "input_metadata[0].name");
+
+    request = effect_request(&agent_request, &support);
+    request.input_metadata[0].value = "v".repeat(257);
+    let long_value = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("long metadata value must fail");
+    assert_eq!(long_value.path(), "input_metadata[0].value");
+
+    request = effect_request(&agent_request, &support);
+    request.input_metadata[0].name = "Provider Display Name".to_owned();
+    validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("metadata names are bounded strings, not normalized identifiers");
+}
+
+#[test]
+fn typed_scopes_reject_invalid_family_specific_values() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let mut request = effect_request(&agent_request, &support);
+    request.requested_scopes[0] = RequestedScope::Process {
+        executable: String::new(),
+        working_directory: "/workspace".to_owned(),
+    };
+
+    let empty_executable = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("empty executable must fail");
+    assert_eq!(empty_executable.path(), "requested_scopes[0].executable");
+
+    request = effect_request(&agent_request, &support);
+    request.requested_scopes[2] = RequestedScope::Network {
+        protocol: NetworkProtocol::Https,
+        host: "crates.io".to_owned(),
+        port: 0,
+    };
+    let zero_port = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("zero network port must fail");
+    assert_eq!(zero_port.path(), "requested_scopes[2].port");
+
+    request = effect_request(&agent_request, &support);
+    request.requested_scopes[1] = RequestedScope::Filesystem {
+        root: "/workspace".to_owned(),
+        access: vec![FilesystemAccess::Read, FilesystemAccess::Read],
+        recursive: true,
+    };
+    let duplicate_access = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("duplicate filesystem access classes must fail");
+    assert_eq!(duplicate_access.path(), "requested_scopes[1].access");
+
+    request = effect_request(&agent_request, &support);
+    request.requested_scopes[0] = RequestedScope::Process {
+        executable: r"C:\Program Files\Cargo\cargo.exe".to_owned(),
+        working_directory: r"C:\workspace".to_owned(),
+    };
+    validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("scope paths remain platform-neutral contract strings");
+}
+
+#[test]
+fn normalized_operations_and_approval_references_fail_closed() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+
+    for (request, expected_path) in [
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.normalized_operation = "filesystem.modify".to_owned();
+                request
+            },
+            "normalized_operation",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.normalized_operation = "process.Spawn".to_owned();
+                request
+            },
+            "normalized_operation",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request.approval_context[0].evidence.evidence_type = EvidenceType::Artifact;
+                request
+            },
+            "approval_context[0].evidence.evidence_type",
+        ),
+        (
+            {
+                let mut request = effect_request(&agent_request, &support);
+                request
+                    .approval_context
+                    .push(request.approval_context[0].clone());
+                request
+            },
+            "approval_context[1].approval_id",
+        ),
+    ] {
+        let error = validate_protected_effect_request(&agent_request, &support, &request)
+            .expect_err("invalid operation or approval reference must fail");
+        assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+        assert_eq!(error.path(), expected_path);
+    }
+}
+
+#[test]
+fn raw_effect_request_rejects_unknown_fields_families_and_repeatability() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let value = serde_json::to_value(request).expect("request should serialize");
+
+    for changed in [
+        {
+            let mut changed = value.clone();
+            changed["provider"] = serde_json::json!("openai");
+            changed
+        },
+        {
+            let mut changed = value.clone();
+            changed["operation_family"] = serde_json::json!("provider_tool");
+            changed
+        },
+        {
+            let mut changed = value.clone();
+            changed["repeatability"] = serde_json::json!("maybe_retry");
+            changed
+        },
+        {
+            let mut changed = value.clone();
+            changed["requested_scopes"][0]
+                .as_object_mut()
+                .expect("process scope should be an object")
+                .remove("executable");
+            changed
+        },
+        {
+            let mut changed = value.clone();
+            changed["requested_scopes"][0]["host"] = serde_json::json!("example.invalid");
+            changed
+        },
+        {
+            let mut changed = value;
+            changed["requested_scopes"][0]["scope_type"] = serde_json::json!("container");
+            changed
+        },
+    ] {
+        let error = parse_protected_effect_request_json(
+            &serde_json::to_vec(&changed).expect("request should serialize"),
+        )
+        .expect_err("unknown contract value must fail");
+        assert_eq!(error.code(), ContractErrorCode::InvalidJson);
+    }
+}

--- a/tests/protected_effect_contracts.rs
+++ b/tests/protected_effect_contracts.rs
@@ -547,6 +547,23 @@ fn normalized_operations_and_approval_references_fail_closed() {
 }
 
 #[test]
+fn approval_context_must_bind_the_current_effect_subject() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let mut request = effect_request(&agent_request, &support);
+    request.approval_context[0].subject_digest = digest('8');
+
+    let error = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect_err("approval evidence for another subject must fail closed");
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "approval_context[0].subject_digest");
+    assert_eq!(
+        error.message(),
+        "approval evidence must bind the Protected Effect Request subject"
+    );
+}
+
+#[test]
 fn raw_effect_request_rejects_unknown_fields_families_and_repeatability() {
     let agent_request = agent_run_request("run-001");
     let support = ContractSupport::new([policy()]);
@@ -854,6 +871,26 @@ fn decision_outcomes_and_execution_statuses_follow_the_authority_matrix() {
         validate_protected_effect_result_body(&agent_request, &support, &request, &body)
             .expect("non-execution authority result should validate");
     }
+}
+
+#[test]
+fn unrelated_gate_cannot_authorize_an_attempted_effect() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let request = effect_request(&agent_request, &support);
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("effect request should validate");
+    let mut body = executed_result_body(&request, &request_digest);
+    body.decision.gate = Gate::Verification;
+
+    let error = validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+        .expect_err("an unrelated gate must not authorize effect execution");
+    assert_eq!(error.code(), ContractErrorCode::UnauthorizedEffect);
+    assert_eq!(error.path(), "body.decision.gate");
+    assert_eq!(
+        error.message(),
+        "an attempted effect requires an allow decision from the permission gate"
+    );
 }
 
 #[test]
@@ -1325,6 +1362,42 @@ fn known_process_results_require_typed_exit_status_and_exit_evidence() {
     let error = validate_protected_effect_result_body(&agent_request, &support, &request, &body)
         .expect_err("known process execution requires exit evidence");
     assert_eq!(error.path(), "body.evidence");
+}
+
+#[test]
+fn non_process_results_reject_process_exit_state() {
+    let agent_request = agent_run_request("run-001");
+    let support = ContractSupport::new([policy()]);
+    let mut request = effect_request(&agent_request, &support);
+    request.operation_family = OperationFamily::Filesystem;
+    request.normalized_operation = "filesystem.write".to_owned();
+    request.requested_scopes = vec![RequestedScope::Filesystem {
+        root: "/workspace".to_owned(),
+        access: vec![FilesystemAccess::Modify],
+        recursive: true,
+    }];
+    let request_digest = validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("filesystem effect request should validate");
+
+    let mut body = executed_result_body(&request, &request_digest);
+    let error = validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+        .expect_err("non-process result must not contain a process exit");
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "body.exit");
+    assert_eq!(
+        error.message(),
+        "only process effects may record an exit status"
+    );
+
+    body.exit = None;
+    let error = validate_protected_effect_result_body(&agent_request, &support, &request, &body)
+        .expect_err("non-process result must not contain process exit evidence");
+    assert_eq!(error.code(), ContractErrorCode::InvalidContract);
+    assert_eq!(error.path(), "body.evidence[0].evidence_type");
+    assert_eq!(
+        error.message(),
+        "only process effects may record exit evidence"
+    );
 }
 
 #[test]

--- a/tests/schema_contracts.rs
+++ b/tests/schema_contracts.rs
@@ -2,8 +2,11 @@ use std::fs;
 use std::path::PathBuf;
 
 use gaap::contracts::{
-    AgentRunStatus, ContractSupport, agent_run_request_schema, parse_agent_run_request_json,
-    parse_terminal_run_receipt_json, terminal_run_receipt_schema, validate_request,
+    AgentRunStatus, ContractSupport, EffectExecutionStatus, agent_run_request_schema,
+    parse_agent_run_request_json, parse_protected_effect_request_json,
+    parse_protected_effect_result_json, parse_terminal_run_receipt_json,
+    protected_effect_request_schema, protected_effect_result_schema, terminal_run_receipt_schema,
+    validate_protected_effect_request, validate_request, verify_protected_effect_result,
     verify_terminal_receipt,
 };
 
@@ -21,6 +24,14 @@ fn generated_contract_schemas_match_the_committed_documents() {
         (
             "schemas/agent-run/v0.1.0/terminal-run-receipt.schema.json",
             terminal_run_receipt_schema(),
+        ),
+        (
+            "schemas/protected-effect/v0.1.0/protected-effect-request.schema.json",
+            protected_effect_request_schema(),
+        ),
+        (
+            "schemas/protected-effect/v0.1.0/protected-effect-result.schema.json",
+            protected_effect_result_schema(),
         ),
     ] {
         let expected = format!(
@@ -102,5 +113,65 @@ fn committed_examples_match_schemas_and_semantic_contracts() {
 
         assert_eq!(receipt.body.terminal_status, expected_status, "{file_name}");
         assert_eq!(receipt.body.terminal_reason, expected_reason, "{file_name}");
+    }
+}
+
+#[test]
+fn committed_protected_effect_examples_match_schemas_and_semantic_contracts() {
+    let root = repository_root();
+    let agent_request_bytes =
+        fs::read(root.join("examples/contracts/v0.1.0/agent-run-request.json"))
+            .expect("Agent Run Request example should be readable");
+    let agent_request = parse_agent_run_request_json(&agent_request_bytes)
+        .expect("Agent Run Request example should parse");
+    let support = ContractSupport::new(agent_request.policies.clone());
+
+    let directory = root.join("examples/contracts/protected-effect/v0.1.0");
+    let request_bytes = fs::read(directory.join("protected-effect-request.json"))
+        .expect("Protected Effect Request example should be readable");
+    let request_value: serde_json::Value = serde_json::from_slice(&request_bytes)
+        .expect("Protected Effect Request example should be JSON");
+    let request_validator = jsonschema::validator_for(&protected_effect_request_schema())
+        .expect("Protected Effect Request schema should compile");
+    request_validator
+        .validate(&request_value)
+        .unwrap_or_else(|error| panic!("Protected Effect Request example is invalid: {error}"));
+    let request = parse_protected_effect_request_json(&request_bytes)
+        .expect("Protected Effect Request example should parse");
+    validate_protected_effect_request(&agent_request, &support, &request)
+        .expect("Protected Effect Request example should validate");
+
+    let result_validator = jsonschema::validator_for(&protected_effect_result_schema())
+        .expect("Protected Effect Result schema should compile");
+    let scenarios = [
+        ("completed.json", EffectExecutionStatus::Executed),
+        ("denied.json", EffectExecutionStatus::Denied),
+        (
+            "awaiting-authority.json",
+            EffectExecutionStatus::AwaitingAuthority,
+        ),
+        ("failed.json", EffectExecutionStatus::Failed),
+        ("interrupted.json", EffectExecutionStatus::Interrupted),
+        ("stale-subject.json", EffectExecutionStatus::Denied),
+        ("schema-drift.json", EffectExecutionStatus::Denied),
+        (
+            "unknown-outcome.json",
+            EffectExecutionStatus::UnknownOutcome,
+        ),
+    ];
+    for (file_name, expected_status) in scenarios {
+        let path = directory.join(file_name);
+        let bytes = fs::read(&path)
+            .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+        let value: serde_json::Value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|error| panic!("{file_name} should be JSON: {error}"));
+        result_validator
+            .validate(&value)
+            .unwrap_or_else(|error| panic!("{file_name} does not match schema: {error}"));
+        let result = parse_protected_effect_result_json(&bytes)
+            .unwrap_or_else(|error| panic!("{file_name} should parse: {error}"));
+        verify_protected_effect_result(&agent_request, &support, &request, &result)
+            .unwrap_or_else(|error| panic!("{file_name} should verify: {error}"));
+        assert_eq!(result.body.execution_status, expected_status, "{file_name}");
     }
 }


### PR DESCRIPTION
## Summary

- define provider-neutral Protected Effect Request and Result v0.1 contracts
- add typed effect scopes, execution-status invariants, RFC 8785 digests, replay and drift protection, and content-addressed evidence
- publish generated Draft 2020-12 schemas, eight result scenarios, one request example, contract documentation, and an ADR
- preserve `RunCoordinator` as the sole decision authority and leave execution, adapters, persistence, signing, sandbox enforcement, and ThreadLoop behavior out of scope

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo build --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps`
- `cargo run --locked --example generate-contract-schemas -- --check`
- `cargo run --locked --example generate-contract-examples -- --check`
- `cargo run --locked --example generate-protected-effect-examples -- --check`
- final Standards review: no P1-P3 findings
- final issue #10 Spec review: no P1-P3 findings

Closes #10
