### PR TITLE
Implement bounded Agent Run runtime

### DIFF
--- a/.github/scripts/select-ci-lanes.sh
+++ b/.github/scripts/select-ci-lanes.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 contract=false
 coordinator=false
+runtime=false
 
 if [[ "${1:-}" == "--uncertain" ]]; then
-  printf 'contract=true\ncoordinator=true\n'
+  printf 'contract=true\ncoordinator=true\nruntime=true\n'
   exit 0
 fi
 
@@ -14,20 +15,29 @@ for changed_path in "$@"; do
     Cargo.toml|Cargo.lock|rust-toolchain.toml|src/lib.rs|.github/*)
       contract=true
       coordinator=true
+      runtime=true
       ;;
-    src/contracts/*|tests/contracts.rs|tests/protected_effect_contracts.rs|schemas/*|examples/contracts/*|examples/generate-contract-artifacts/*|docs/contracts/*|docs/adr/0003-*|docs/adr/0004-*)
+    src/contracts/*|tests/contracts.rs|tests/protected_effect_contracts.rs)
+      contract=true
+      runtime=true
+      ;;
+    schemas/*|examples/contracts/*|examples/generate-contract-artifacts/*|docs/contracts/*|docs/adr/0003-*|docs/adr/0004-*)
       contract=true
       ;;
     src/main.rs|tests/cli.rs|evidence/*|docs/adr/0001-*|docs/adr/0002-*)
       coordinator=true
+      ;;
+    src/runtime.rs|tests/runtime.rs|docs/adr/0005-*)
+      runtime=true
       ;;
     README.md|CONTRIBUTING.md|LICENSE*|docs/*)
       ;;
     *)
       contract=true
       coordinator=true
+      runtime=true
       ;;
   esac
 done
 
-printf 'contract=%s\ncoordinator=%s\n' "$contract" "$coordinator"
+printf 'contract=%s\ncoordinator=%s\nruntime=%s\n' "$contract" "$coordinator" "$runtime"

--- a/.github/scripts/test-select-ci-lanes.sh
+++ b/.github/scripts/test-select-ci-lanes.sh
@@ -17,21 +17,26 @@ assert_lanes() {
   fi
 }
 
-contract_only=$'contract=true\ncoordinator=false'
-coordinator_only=$'contract=false\ncoordinator=true'
-both=$'contract=true\ncoordinator=true'
-baseline_only=$'contract=false\ncoordinator=false'
+contract_only=$'contract=true\ncoordinator=false\nruntime=false'
+contract_runtime=$'contract=true\ncoordinator=false\nruntime=true'
+coordinator_only=$'contract=false\ncoordinator=true\nruntime=false'
+runtime_only=$'contract=false\ncoordinator=false\nruntime=true'
+all=$'contract=true\ncoordinator=true\nruntime=true'
+baseline_only=$'contract=false\ncoordinator=false\nruntime=false'
 
-assert_lanes "$contract_only" src/contracts/model.rs
+assert_lanes "$contract_runtime" src/contracts/model.rs
 assert_lanes "$contract_only" schemas/agent-run/v0.1.0/agent-run-request.schema.json
 assert_lanes "$contract_only" examples/generate-contract-artifacts/catalog.rs
 assert_lanes "$coordinator_only" src/main.rs
 assert_lanes "$coordinator_only" evidence/run-invariant-subject-v0.1.0.json
-assert_lanes "$both" src/contracts/model.rs src/main.rs
-assert_lanes "$both" .github/workflows/ci.yml
-assert_lanes "$both" Cargo.lock
-assert_lanes "$both" src/future-runtime.rs
-assert_lanes "$both" --uncertain
+assert_lanes "$runtime_only" src/runtime.rs
+assert_lanes "$runtime_only" tests/runtime.rs
+assert_lanes "$runtime_only" docs/adr/0005-bounded-agent-run-engine.md
+assert_lanes "$all" src/contracts/model.rs src/main.rs
+assert_lanes "$all" .github/workflows/ci.yml
+assert_lanes "$all" Cargo.lock
+assert_lanes "$all" src/future-runtime.rs
+assert_lanes "$all" --uncertain
 assert_lanes "$baseline_only" README.md
 assert_lanes "$baseline_only" docs/research/new-note.md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       contract: ${{ steps.lanes.outputs.contract }}
       coordinator: ${{ steps.lanes.outputs.coordinator }}
+      runtime: ${{ steps.lanes.outputs.runtime }}
     steps:
       - name: Check out GAAP history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -130,6 +131,18 @@ jobs:
             evidence/run-invariant-subject-v0.1.0.json \
             /tmp/run-invariant-subject.json
 
+  runtime:
+    needs: classify
+    if: needs.classify.outputs.runtime == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out GAAP
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check bounded Agent Run runtime
+        run: cargo test --locked --test runtime
+
   final:
     if: always()
     needs:
@@ -137,6 +150,7 @@ jobs:
       - baseline
       - contract
       - coordinator
+      - runtime
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -148,6 +162,8 @@ jobs:
           CONTRACT_RESULT: ${{ needs.contract.result }}
           COORDINATOR_SELECTED: ${{ needs.classify.outputs.coordinator }}
           COORDINATOR_RESULT: ${{ needs.coordinator.result }}
+          RUNTIME_SELECTED: ${{ needs.classify.outputs.runtime }}
+          RUNTIME_RESULT: ${{ needs.runtime.result }}
         run: |
           set -euo pipefail
           [[ "$CLASSIFY_RESULT" == "success" ]]
@@ -161,4 +177,9 @@ jobs:
             [[ "$COORDINATOR_RESULT" == "success" ]]
           else
             [[ "$COORDINATOR_RESULT" == "skipped" ]]
+          fi
+          if [[ "$RUNTIME_SELECTED" == "true" ]]; then
+            [[ "$RUNTIME_RESULT" == "success" ]]
+          else
+            [[ "$RUNTIME_RESULT" == "skipped" ]]
           fi

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ GAAP is a Rust library and CLI that evaluates normalized plan, permission,
 tool-trust, verification, runtime, mutation, and completion decisions for an
 agent run.
 
-The current executable slice provides the integrity coordinator that a future
-agent loop will call before protected effects. It does not yet execute models,
-tools, repository mutations, sandboxes, or verifiers.
+The current executable slice provides the integrity coordinator, frozen
+contracts, and a deterministic Rust runtime that calls explicit adapter ports
+before protected effects. It does not yet include provider adapters,
+persistence, signing, sandbox enforcement, or ThreadLoop integration.
 
 ## Current Interfaces And Evidence
 
 | Path or interface | Current behavior | Developer use |
 | --- | --- | --- |
 | [`RunCoordinator::evaluate(gate, input)`](./src/lib.rs) | Accepts a typed `Gate` and normalized JSON input, then returns an `allow`, `ask`, or `block` decision with a code and effects. | Put one deterministic decision module behind future provider, tool, and runtime adapters. |
+| [`gaap::runtime`](./src/runtime.rs) | Runs one bounded Agent Run through plan, permission, tool-trust, runtime, workflow, execution, and verification ports, then seals exactly one Terminal Run Receipt. | Test runtime lifecycle behavior without provider SDKs, persistence, or real sandbox/executor integrations. |
 | [`gaap::contracts`](./src/contracts) | Defines and validates provider-neutral Agent Run and Protected Effect `0.1.0` contracts. | Parse, canonicalize, validate, seal, and verify immutable contract values without importing provider SDK types. |
 | [`gaap::contracts::protected_effect`](./src/contracts/protected_effect) | Defines typed effect scopes, request binding, result-state invariants, evidence references, and replay/tamper checks. It performs no effect or policy evaluation. | Integrate a future executor at one small contract seam while keeping `RunCoordinator` authoritative. |
 | [`schemas/agent-run/v0.1.0`](./schemas/agent-run/v0.1.0) | Freezes Draft 2020-12 request and receipt schemas with strict fields, versions, enums, digests, and safe integers. | Generate or validate cross-language contract documents. |
@@ -34,7 +36,7 @@ GAAP does not import or vendor RunInvariant.
 Implemented and tested now:
 
 - a Rust `RunCoordinator` with one public evaluation interface;
-- plan approval bound to the exact plan digest;
+- plan approval bound to the exact subject digest;
 - deny precedence and explicit approval for risky or unknown actions;
 - capability approval bound to an exact capability digest;
 - independent, subject-bound, evidence-bearing verification;
@@ -50,6 +52,13 @@ Implemented and tested now:
 - parent-bound request digests and sealed, replay-resistant result digests;
 - fail-closed decision/status, observed-identity, drift, evidence, and
   non-execution invariants;
+- a Rust `gaap::runtime` engine around `RunCoordinator` with narrow agent,
+  executor, and verifier ports;
+- runtime-only trusted capability support for the `ToolTrust` gate without
+  changing the frozen `0.1.0` contracts;
+- deterministic protected-effect execution through test executor ports,
+  one-shot ask blocking, unknown-outcome separation, interruption evidence, and
+  stale-verification rejection;
 - generated Draft 2020-12 JSON Schemas; and
 - Agent Run terminal examples plus completed/executed, denied,
   awaiting-authority, failed, interrupted, stale-subject, schema-drift, and
@@ -57,13 +66,13 @@ Implemented and tested now:
 
 Not implemented yet:
 
-- a bounded or open-ended model and tool execution loop;
 - OpenAI, Anthropic, MCP, or other provider adapters;
-- Protected Effect execution, retry orchestration, reconciliation, or
-  persistence;
+- production Protected Effect executor adapters, retry orchestration,
+  reconciliation, or persistence;
 - repository mutation interception;
 - approval persistence, revocation, or delegated authority;
-- sandbox, budget-meter, verifier, or evidence-ledger adapters; and
+- sandbox, budget-meter, verifier, or evidence-ledger adapters beyond the Rust
+  test ports; and
 - crash recovery or resumable run state.
 
 The conformance packet proves normalized decision compatibility for the frozen
@@ -126,14 +135,16 @@ RunInvariant commit and fails if the packet changes.
 
 ## Architecture Direction
 
-The `RunCoordinator` is the deep module at the integrity seam. Both the
-RunInvariant adapter and the future agent loop call the same interface; neither
+The `RunCoordinator` is the deep module at the integrity seam. The RunInvariant
+adapter and the bounded runtime call the same interface; neither
 provider-specific message types nor transport details enter the coordinator.
 
-The next runtime slice must own lifecycle advancement around the coordinator:
-plan, authorize mutation, execute through explicit adapters, account for
-resources, obtain independent verification for the current artifact digest,
-and authorize completion only if no later mutation invalidated that evidence.
+The runtime owns lifecycle advancement around the coordinator: plan, authorize
+mutation, execute through explicit adapters, account for resources, obtain
+independent verification for the current artifact digest, and authorize
+completion only if no later mutation invalidated that evidence. Future adapter
+slices can bind that runtime to providers, sandboxes, persistence, and
+ThreadLoop without changing the frozen `0.1.0` contracts.
 
 Architecture decisions:
 
@@ -141,6 +152,7 @@ Architecture decisions:
 - [`0002: Use an external conformance seam`](./docs/adr/0002-run-invariant-process-seam.md)
 - [`0003: Freeze the Agent Run contract as canonical evidence`](./docs/adr/0003-freeze-agent-run-contract.md)
 - [`0004: Separate Protected Effect contracts from execution`](./docs/adr/0004-protected-effect-contract-boundary.md)
+- [`0005: Add a bounded Agent Run engine`](./docs/adr/0005-bounded-agent-run-engine.md)
 
 The normative contract guide is
 [`Agent Run Contract 0.1.0`](./docs/contracts/agent-run-v0.1.md). Contract
@@ -150,7 +162,7 @@ interoperability, not producer authenticity.
 The inner effect boundary is defined by
 [`Protected Effect Contract 0.1.0`](./docs/contracts/protected-effect-v0.1.md).
 Its validators check contract consistency; they do not replace
-`RunCoordinator`, execute effects, or implement the bounded runtime.
+`RunCoordinator` or grant effect authority.
 
 ## Pattern Library
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ persistence, signing, sandbox enforcement, or ThreadLoop integration.
 | Path or interface | Current behavior | Developer use |
 | --- | --- | --- |
 | [`RunCoordinator::evaluate(gate, input)`](./src/lib.rs) | Accepts a typed `Gate` and normalized JSON input, then returns an `allow`, `ask`, or `block` decision with a code and effects. | Put one deterministic decision module behind future provider, tool, and runtime adapters. |
-| [`gaap::runtime`](./src/runtime.rs) | Runs one bounded Agent Run through plan, permission, tool-trust, runtime, workflow, execution, and verification ports, then seals exactly one Terminal Run Receipt. | Test runtime lifecycle behavior without provider SDKs, persistence, or real sandbox/executor integrations. |
+| [`gaap::runtime`](./src/runtime.rs) | Runs one bounded Agent Run through plan, runtime-owned permission/tool-trust/runtime gates, workflow, execution, and verification ports, then seals exactly one Terminal Run Receipt. | Test runtime lifecycle behavior without provider SDKs, persistence, or real sandbox/executor integrations. |
 | [`gaap::contracts`](./src/contracts) | Defines and validates provider-neutral Agent Run and Protected Effect `0.1.0` contracts. | Parse, canonicalize, validate, seal, and verify immutable contract values without importing provider SDK types. |
 | [`gaap::contracts::protected_effect`](./src/contracts/protected_effect) | Defines typed effect scopes, request binding, result-state invariants, evidence references, and replay/tamper checks. It performs no effect or policy evaluation. | Integrate a future executor at one small contract seam while keeping `RunCoordinator` authoritative. |
 | [`schemas/agent-run/v0.1.0`](./schemas/agent-run/v0.1.0) | Freezes Draft 2020-12 request and receipt schemas with strict fields, versions, enums, digests, and safe integers. | Generate or validate cross-language contract documents. |
@@ -53,12 +53,13 @@ Implemented and tested now:
 - fail-closed decision/status, observed-identity, drift, evidence, and
   non-execution invariants;
 - a Rust `gaap::runtime` engine around `RunCoordinator` with narrow agent,
-  executor, and verifier ports;
-- runtime-only trusted capability support for the `ToolTrust` gate without
-  changing the frozen `0.1.0` contracts;
+  executor, and verifier ports plus explicit port usage accounting;
+- runtime-only support for trusted capabilities, permission policy, overage
+  approvals, verifier identities, and effect usage estimates without changing
+  the frozen `0.1.0` contracts;
 - deterministic protected-effect execution through test executor ports,
-  one-shot ask blocking, unknown-outcome separation, interruption evidence, and
-  stale-verification rejection;
+  one-shot ask blocking, duplicate-effect rejection, unknown-outcome
+  separation, interruption evidence, and stale-verification rejection;
 - generated Draft 2020-12 JSON Schemas; and
 - Agent Run terminal examples plus completed/executed, denied,
   awaiting-authority, failed, interrupted, stale-subject, schema-drift, and

--- a/docs/adr/0005-bounded-agent-run-engine.md
+++ b/docs/adr/0005-bounded-agent-run-engine.md
@@ -1,0 +1,40 @@
+# ADR 0005: Add A Bounded Agent Run Engine
+
+Status: Accepted
+
+## Decision
+
+GAAP will expose a Rust-only bounded Agent Run runtime around
+`RunCoordinator`. The runtime validates one `AgentRunRequest`, asks an
+`AgentAdapter` for an approved plan and bounded next steps, evaluates every
+protected effect through the coordinator, executes only fully allowed
+`ProtectedEffectRequest` values through an `ExecutorPort`, invokes independent
+verification through a `VerifierPort`, and seals exactly one
+`TerminalRunReceipt`.
+
+The runtime records each attempted or declined protected effect as a sealed
+`ProtectedEffectResult`. It terminalizes one-shot `ask` outcomes as
+`blocked`, without treating missing authority as an allow. It preserves
+`failed`, `interrupted`, `blocked`, and `unknown_outcome` as distinct terminal
+paths in the receipt ledger.
+
+Tool-trust authority is runtime support metadata, not a new contract field.
+`RuntimeSupport` carries exact trusted `CapabilityIdentity` values. When a
+proposed effect uses one of those capabilities, the runtime translates that
+support into the coordinator's capability-bound `ToolTrust` input shape. The
+frozen Agent Run and Protected Effect `0.1.0` approval references remain
+subject-bound evidence references.
+
+## Consequences
+
+- `RunCoordinator` remains the only gate decision authority.
+- Contract validators remain consistency checkers; they do not grant runtime
+  authority.
+- The public runtime API is a Rust module first. No CLI, provider adapter,
+  persistence, signing, sandbox implementation, MCP/ACP bridge, or ThreadLoop
+  integration is introduced by this slice.
+- In-memory deterministic adapters are enough to prove lifecycle behavior,
+  protected-effect sealing, terminal receipt sealing, budget gating, and
+  stale-verification rejection.
+- Any later cross-language runtime boundary or persisted run state must be
+  versioned separately from the frozen `0.1.0` contracts.

--- a/docs/adr/0005-bounded-agent-run-engine.md
+++ b/docs/adr/0005-bounded-agent-run-engine.md
@@ -6,24 +6,28 @@ Status: Accepted
 
 GAAP will expose a Rust-only bounded Agent Run runtime around
 `RunCoordinator`. The runtime validates one `AgentRunRequest`, asks an
-`AgentAdapter` for an approved plan and bounded next steps, evaluates every
-protected effect through the coordinator, executes only fully allowed
-`ProtectedEffectRequest` values through an `ExecutorPort`, invokes independent
-verification through a `VerifierPort`, and seals exactly one
-`TerminalRunReceipt`.
+`AgentAdapter` for a plan and bounded next steps, evaluates every protected
+effect through runtime-owned permission, tool-trust, runtime, and workflow
+inputs, executes only fully allowed `ProtectedEffectRequest` values through an
+`ExecutorPort`, invokes trusted independent verification through a
+`VerifierPort`, and seals exactly one `TerminalRunReceipt`.
 
 The runtime records each attempted or declined protected effect as a sealed
-`ProtectedEffectResult`. It terminalizes one-shot `ask` outcomes as
-`blocked`, without treating missing authority as an allow. It preserves
-`failed`, `interrupted`, `blocked`, and `unknown_outcome` as distinct terminal
-paths in the receipt ledger.
+`ProtectedEffectResult`. It enforces contiguous effect sequences, unique effect
+identities, trusted usage estimates, port usage accounting, and JCS-safe
+cumulative usage before invoking the executor. It terminalizes one-shot `ask`
+outcomes as `blocked`, without treating missing authority as an allow. It
+preserves `failed`, `interrupted`, `blocked`, and `unknown_outcome` as distinct
+terminal paths in the receipt ledger.
 
-Tool-trust authority is runtime support metadata, not a new contract field.
-`RuntimeSupport` carries exact trusted `CapabilityIdentity` values. When a
-proposed effect uses one of those capabilities, the runtime translates that
-support into the coordinator's capability-bound `ToolTrust` input shape. The
-frozen Agent Run and Protected Effect `0.1.0` approval references remain
-subject-bound evidence references.
+Tool-trust, permission, runtime overage, and verifier authority are runtime
+support metadata, not new contract fields. `RuntimeSupport` carries exact
+trusted `CapabilityIdentity` values, runtime-owned permission policy and
+effect approvals, runtime overage approvals, trusted verifier IDs, and trusted
+effect usage estimates. When a proposed effect uses one of those capabilities,
+the runtime translates that support into the coordinator's capability-bound
+`ToolTrust` input shape. The frozen Agent Run and Protected Effect `0.1.0`
+approval references remain subject-bound evidence references.
 
 ## Consequences
 
@@ -34,7 +38,8 @@ subject-bound evidence references.
   persistence, signing, sandbox implementation, MCP/ACP bridge, or ThreadLoop
   integration is introduced by this slice.
 - In-memory deterministic adapters are enough to prove lifecycle behavior,
-  protected-effect sealing, terminal receipt sealing, budget gating, and
-  stale-verification rejection.
+  protected-effect sealing, terminal receipt sealing, budget gating, duplicate
+  admission rejection, executor-outcome normalization, and stale-verification
+  rejection.
 - Any later cross-language runtime boundary or persisted run state must be
   versioned separately from the frozen `0.1.0` contracts.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub mod contracts;
+pub mod runtime;
 
 const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const DANGEROUS_RISK_TAGS: &[&str] = &["destructive_flag", "destructive_path"];

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -710,6 +710,16 @@ where
                 )
                 .map(|execution| EffectHandling::Terminal(Box::new(execution)));
         }
+        if observation.sandbox_profile.as_ref() != Some(&proposal.request.sandbox_profile) {
+            let _usage_reason = ledger.record_effect_usage(&observation.usage);
+            return self
+                .finish(
+                    ledger,
+                    AgentRunStatus::Failed,
+                    "protected_effect.untrusted_sandbox",
+                )
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
         let effect_result = self.attempt_result(
             &ledger,
             &proposal.request,
@@ -984,7 +994,7 @@ where
             exit: observation.exit,
             usage: observation.usage,
             executor: Some(self.config.executor_identity.clone()),
-            sandbox_profile: Some(request.sandbox_profile.clone()),
+            sandbox_profile: observation.sandbox_profile,
             reason: observation.reason,
             evidence: observation.evidence,
         };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -711,7 +711,42 @@ where
                 .map(|execution| EffectHandling::Terminal(Box::new(execution)));
         }
         if observation.sandbox_profile.as_ref() != Some(&proposal.request.sandbox_profile) {
-            let _usage_reason = ledger.record_effect_usage(&observation.usage);
+            let effect_result = self.untrusted_sandbox_result(
+                &ledger,
+                &proposal.request,
+                &effect_digest,
+                ProtectedEffectDecision {
+                    decision_id: permission_decision_id.clone(),
+                    gate: Gate::Permission,
+                    effect_request_digest: effect_digest.clone(),
+                    subject_digest: ledger.current_subject.digest.clone(),
+                    decision: permission_decision,
+                },
+                observation,
+            )?;
+            ledger.accept_effect_identity(&proposal.request, &effect_digest);
+            ledger.tool_execution(
+                &permission_decision_id,
+                &effect_digest,
+                &proposal.request.capability.digest,
+                &effect_result,
+            );
+            if let Some(post_subject) = effect_result.body.observed_post_effect_subject.clone() {
+                if proposal.request.expected_effect_class == EffectClass::Mutation {
+                    let workflow_decision_id = workflow_decision_id
+                        .as_deref()
+                        .expect("mutation effects require a workflow decision");
+                    ledger.mutation(
+                        workflow_decision_id,
+                        &effect_digest,
+                        &post_subject.digest,
+                        &effect_result.body.evidence,
+                    );
+                    ledger.current_subject = post_subject;
+                }
+            }
+            let _usage_reason = ledger.record_effect_usage(&effect_result.body.usage);
+            ledger.effect_results.push(effect_result);
             return self
                 .finish(
                     ledger,
@@ -960,6 +995,89 @@ where
             sandbox_profile: None,
             reason: Some(outcome.reason),
             evidence: outcome.evidence,
+        };
+        seal_protected_effect_result(
+            &ledger.request,
+            self.support.contract_support(),
+            request,
+            body,
+        )
+        .map_err(RuntimeError::ProtectedEffectResult)
+    }
+
+    fn untrusted_sandbox_result(
+        &self,
+        ledger: &Ledger,
+        request: &ProtectedEffectRequest,
+        effect_digest: &str,
+        decision: ProtectedEffectDecision,
+        observation: ExecutorObservation,
+    ) -> Result<ProtectedEffectResult, RuntimeError> {
+        let mut evidence = observation.evidence;
+        evidence.retain(|reference| {
+            !matches!(
+                reference.evidence_type,
+                EffectEvidenceType::Failure | EffectEvidenceType::Interruption
+            )
+        });
+        ensure_effect_evidence(&mut evidence, EffectEvidenceType::Executor, "executor");
+        ensure_effect_evidence(
+            &mut evidence,
+            EffectEvidenceType::Sandbox,
+            "untrusted-sandbox",
+        );
+        ensure_effect_evidence(&mut evidence, EffectEvidenceType::Usage, "usage");
+        ensure_effect_evidence(
+            &mut evidence,
+            EffectEvidenceType::UnknownOutcome,
+            "untrusted-sandbox-unknown-outcome",
+        );
+        if observation.observed_post_effect_subject.is_some() {
+            ensure_effect_evidence(
+                &mut evidence,
+                EffectEvidenceType::SubjectObservation,
+                "untrusted-sandbox-subject",
+            );
+            if request.expected_effect_class == EffectClass::Mutation {
+                ensure_effect_evidence(
+                    &mut evidence,
+                    EffectEvidenceType::Mutation,
+                    "untrusted-sandbox-mutation",
+                );
+                ensure_effect_evidence(
+                    &mut evidence,
+                    EffectEvidenceType::Artifact,
+                    "untrusted-sandbox-artifact",
+                );
+            }
+        }
+
+        let reason = observation
+            .reason
+            .filter(|reason| !reason.trim().is_empty())
+            .map_or_else(
+                || "protected_effect.untrusted_sandbox".to_string(),
+                |reason| format!("protected_effect.untrusted_sandbox: {reason}"),
+            );
+        let body = ProtectedEffectResultBody {
+            schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+            effect_id: request.effect_id.clone(),
+            effect_sequence: request.effect_sequence,
+            run_id: request.run_id.clone(),
+            agent_run_request_digest: request.agent_run_request_digest.clone(),
+            effect_request_digest: effect_digest.to_owned(),
+            observed_pre_effect_subject: ledger.current_subject.clone(),
+            observed_capability: request.capability.clone(),
+            observed_tool_schema_digest: request.tool_schema_digest.clone(),
+            decision,
+            execution_status: EffectExecutionStatus::UnknownOutcome,
+            observed_post_effect_subject: observation.observed_post_effect_subject,
+            exit: None,
+            usage: observation.usage,
+            executor: Some(self.config.executor_identity.clone()),
+            sandbox_profile: Some(request.sandbox_profile.clone()),
+            reason: Some(reason),
+            evidence,
         };
         seal_protected_effect_result(
             &ledger.request,
@@ -1657,6 +1775,19 @@ fn runtime_effect_evidence(
         evidence_type,
         digest: digest_bytes(format!("gaap:runtime/effect-evidence:{label}").as_bytes()),
         locator: Some(format!("gaap:runtime/{label}")),
+    }
+}
+
+fn ensure_effect_evidence(
+    evidence: &mut Vec<EffectEvidenceReference>,
+    evidence_type: EffectEvidenceType,
+    label: &str,
+) {
+    if !evidence
+        .iter()
+        .any(|reference| reference.evidence_type == evidence_type)
+    {
+        evidence.push(runtime_effect_evidence(evidence_type, label));
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 
@@ -7,7 +8,7 @@ use sha2::{Digest, Sha256};
 use crate::contracts::{
     AgentRunRequest, AgentRunStatus, ApprovalReference, CapabilityIdentity, ContractError,
     ContractSupport, EffectClass, EffectEvidenceReference, EffectEvidenceType,
-    EffectExecutionStatus, EffectUsage, EvidenceReference, EvidenceType,
+    EffectExecutionStatus, EffectUsage, EvidenceReference, EvidenceType, ExecutorIdentity,
     PROTECTED_EFFECT_RESULT_SCHEMA, ProtectedEffectDecision, ProtectedEffectRequest,
     ProtectedEffectResult, ProtectedEffectResultBody, ResourceUsage, RunEvent,
     TERMINAL_RUN_RECEIPT_SCHEMA, TerminalRunReceipt, TerminalRunReceiptBody, VerificationVerdict,
@@ -28,17 +29,29 @@ pub struct AgentRunExecution {
 pub struct RuntimeSupport {
     contract_support: ContractSupport,
     trusted_capabilities: Vec<CapabilityIdentity>,
+    permission_policy: PermissionPolicy,
+    protected_effect_usage_estimate: EffectUsage,
+    runtime_approvals: Vec<GateApproval>,
+    trusted_verifier_ids: Vec<String>,
 }
 
 impl RuntimeSupport {
-    /// Construct runtime support from contract policy support and trusted capabilities.
+    /// Construct runtime support from trusted, runtime-owned gate inputs.
     pub fn new(
         contract_support: ContractSupport,
         trusted_capabilities: Vec<CapabilityIdentity>,
+        permission_policy: PermissionPolicy,
+        protected_effect_usage_estimate: EffectUsage,
+        runtime_approvals: Vec<GateApproval>,
+        trusted_verifier_ids: Vec<String>,
     ) -> Self {
         Self {
             contract_support,
             trusted_capabilities,
+            permission_policy,
+            protected_effect_usage_estimate,
+            runtime_approvals,
+            trusted_verifier_ids,
         }
     }
 
@@ -51,6 +64,26 @@ impl RuntimeSupport {
         self.trusted_capabilities
             .iter()
             .any(|trusted| trusted == capability)
+    }
+
+    fn permission_policy(&self) -> &PermissionPolicy {
+        &self.permission_policy
+    }
+
+    fn protected_effect_usage_estimate(&self) -> &EffectUsage {
+        &self.protected_effect_usage_estimate
+    }
+
+    fn runtime_approval_for(&self, action_digest: &str) -> Option<&GateApproval> {
+        self.runtime_approvals
+            .iter()
+            .find(|approval| approval.subject_digest == action_digest)
+    }
+
+    fn trusts_verifier(&self, verifier_id: &str) -> bool {
+        self.trusted_verifier_ids
+            .iter()
+            .any(|trusted| trusted == verifier_id)
     }
 }
 
@@ -66,6 +99,7 @@ pub struct BudgetThresholds {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeConfig {
     pub implementer_id: String,
+    pub executor_identity: ExecutorIdentity,
     pub max_effects: u64,
     pub budget_thresholds: BudgetThresholds,
 }
@@ -77,11 +111,10 @@ pub struct GateApproval {
     pub max_cost_micros: Option<u64>,
 }
 
-/// The adapter's approved plan proposal.
+/// The adapter's proposed plan digest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlanProposal {
     pub plan_digest: String,
-    pub approval: Option<ApprovalReference>,
 }
 
 /// A policy decision supplied by a deterministic policy adapter.
@@ -102,21 +135,34 @@ impl PolicyDecision {
     }
 }
 
-/// Permission gate input attached to one proposed protected effect.
+/// Runtime-owned policy input for protected-effect permission decisions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PermissionInput {
+pub struct PermissionPolicy {
     pub policy_decision: Option<PolicyDecision>,
     pub risk_tags: Vec<String>,
     pub wrapper_chain: Vec<String>,
-    pub approval: Option<GateApproval>,
+    pub approvals: Vec<GateApproval>,
+}
+
+impl PermissionPolicy {
+    fn approval_for(&self, action_digest: &str) -> Option<&GateApproval> {
+        self.approvals
+            .iter()
+            .find(|approval| approval.subject_digest == action_digest)
+    }
 }
 
 /// One protected effect proposal from the agent adapter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProtectedEffectProposal {
     pub request: ProtectedEffectRequest,
-    pub permission: PermissionInput,
-    pub estimated_cost_micros: u64,
+}
+
+/// One adapter or verifier output plus the resources consumed to produce it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortObservation<T> {
+    pub value: T,
+    pub usage: ResourceUsage,
 }
 
 /// A bounded next step from the agent adapter.
@@ -175,9 +221,15 @@ pub struct VerificationContext<'a> {
 
 /// Narrow adapter that can propose a plan and the next bounded effect.
 pub trait AgentAdapter {
-    fn plan(&mut self, request: &AgentRunRequest) -> Result<PlanProposal, RuntimePortError>;
+    fn plan(
+        &mut self,
+        request: &AgentRunRequest,
+    ) -> Result<PortObservation<PlanProposal>, RuntimePortError>;
 
-    fn next_effect(&mut self, context: AgentRunContext<'_>) -> Result<AgentStep, RuntimePortError>;
+    fn next_effect(
+        &mut self,
+        context: AgentRunContext<'_>,
+    ) -> Result<PortObservation<AgentStep>, RuntimePortError>;
 }
 
 /// Narrow executor port used only after all mutation gates allow.
@@ -193,7 +245,7 @@ pub trait VerifierPort {
     fn verify(
         &mut self,
         context: VerificationContext<'_>,
-    ) -> Result<VerificationReport, RuntimePortError>;
+    ) -> Result<PortObservation<VerificationReport>, RuntimePortError>;
 }
 
 /// Failure returned by a runtime adapter port.
@@ -302,13 +354,14 @@ where
 
     pub fn run(&mut self, request: AgentRunRequest) -> Result<AgentRunExecution, RuntimeError> {
         validate_config(&self.config, &request)?;
+        validate_support(&self.support)?;
         let request_digest = validate_request(&request, self.support.contract_support())
             .map_err(RuntimeError::Contract)?;
         let mut ledger = Ledger::new(request.clone(), request_digest);
 
         ledger.transition(AgentRunStatus::Planning, None);
-        let plan = match self.agent.plan(&request) {
-            Ok(plan) => plan,
+        let plan_observation = match self.agent.plan(&request) {
+            Ok(observation) => observation,
             Err(error) => {
                 return self.finish(
                     ledger,
@@ -317,26 +370,35 @@ where
                 );
             }
         };
+        if let Some(reason) = ledger.record_usage(&plan_observation.usage) {
+            return self.finish(ledger, AgentRunStatus::Blocked, reason);
+        }
 
+        let plan = plan_observation.value;
+        if !is_digest_string(&plan.plan_digest) {
+            return self.finish(ledger, AgentRunStatus::Failed, "plan.invalid_digest");
+        }
         ledger.plan_recorded(plan.plan_digest.clone());
-        if let Some(approval) = plan.approval.clone() {
+        let plan_approval = plan_approval_for(&request, &ledger.current_subject.digest);
+        if let Some(approval) = plan_approval.cloned() {
             ledger.approval_recorded(approval);
         }
-        let plan_decision = self
-            .coordinator
-            .evaluate(Gate::Plan, &plan_input(&ledger.current_subject, &plan));
+        let plan_decision = self.coordinator.evaluate(
+            Gate::Plan,
+            &plan_input(&ledger.current_subject, plan_approval),
+        );
         if plan_decision.outcome != Outcome::Allow {
             return self.finish(ledger, AgentRunStatus::Blocked, plan_decision.code);
         }
 
         ledger.transition(AgentRunStatus::Executing, None);
         loop {
-            let step = match self.agent.next_effect(AgentRunContext {
+            let step_observation = match self.agent.next_effect(AgentRunContext {
                 current_subject: &ledger.current_subject,
                 usage: &ledger.usage,
                 effects_seen: ledger.effects_seen,
             }) {
-                Ok(step) => step,
+                Ok(observation) => observation,
                 Err(error) => {
                     return self.finish(
                         ledger,
@@ -345,16 +407,12 @@ where
                     );
                 }
             };
+            if let Some(reason) = ledger.record_usage(&step_observation.usage) {
+                return self.finish(ledger, AgentRunStatus::Blocked, reason);
+            }
 
-            match step {
+            match step_observation.value {
                 AgentStep::ProtectedEffect(proposal) => {
-                    if ledger.effects_seen >= self.config.max_effects {
-                        return self.finish(
-                            ledger,
-                            AgentRunStatus::Blocked,
-                            "runtime.max_effects_exhausted",
-                        );
-                    }
                     match self.handle_protected_effect(ledger, *proposal)? {
                         EffectHandling::Continue(next) => {
                             ledger = *next;
@@ -368,7 +426,7 @@ where
                     return self.verify_and_finish(ledger);
                 }
                 AgentStep::Cancel(cancellation) => {
-                    ledger.interruption(cancellation);
+                    ledger.interruption(sanitize_cancellation(cancellation));
                     return self.finish(ledger, AgentRunStatus::Interrupted, "runtime.interrupted");
                 }
             }
@@ -380,7 +438,6 @@ where
         mut ledger: Ledger,
         proposal: ProtectedEffectProposal,
     ) -> Result<EffectHandling, RuntimeError> {
-        ledger.effects_seen += 1;
         let effect_digest = match validate_protected_effect_request(
             &ledger.request,
             self.support.contract_support(),
@@ -398,55 +455,59 @@ where
             }
         };
 
+        if let Some(decision) =
+            ledger.admission_decision(&proposal.request, &effect_digest, self.config.max_effects)
+        {
+            return self
+                .decline_protected_effect(
+                    ledger,
+                    &proposal.request,
+                    &effect_digest,
+                    Gate::Runtime,
+                    decision,
+                )
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
         if proposal.request.subject != ledger.current_subject {
             let decision = Decision {
                 outcome: Outcome::Block,
                 code: "protected_effect.stale_subject".to_string(),
                 effects: vec!["stop_action".to_string()],
             };
-            let decision_id = decision_id("subject", proposal.request.effect_sequence);
-            ledger.protected_effect_decision(
-                &decision_id,
-                Gate::Permission,
-                &effect_digest,
-                decision.clone(),
-            );
-            let result = self.non_execution_result(
-                &ledger,
-                &proposal.request,
-                &effect_digest,
-                NonExecutionOutcome {
-                    decision: ProtectedEffectDecision {
-                        decision_id,
-                        gate: Gate::Permission,
-                        effect_request_digest: effect_digest.clone(),
-                        subject_digest: ledger.current_subject.digest.clone(),
-                        decision,
-                    },
-                    execution_status: EffectExecutionStatus::Denied,
-                    reason: "protected_effect.stale_subject".to_string(),
-                    evidence: vec![EffectEvidenceReference {
-                        evidence_type: EffectEvidenceType::SubjectObservation,
-                        digest: digest_bytes(ledger.current_subject.digest.as_bytes()),
-                        locator: Some("gaap:runtime/current-subject".to_string()),
-                    }],
-                },
-            )?;
-            ledger.effect_results.push(result);
             return self
-                .finish(
+                .decline_protected_effect(
                     ledger,
-                    AgentRunStatus::Blocked,
-                    "protected_effect.stale_subject",
+                    &proposal.request,
+                    &effect_digest,
+                    Gate::Permission,
+                    decision,
+                )
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
+        if let Some(decision) = budget_admission_decision(
+            &ledger.usage,
+            &ledger.request.resource_budget,
+            self.support.protected_effect_usage_estimate(),
+        ) {
+            return self
+                .decline_protected_effect(
+                    ledger,
+                    &proposal.request,
+                    &effect_digest,
+                    Gate::Runtime,
+                    decision,
                 )
                 .map(|execution| EffectHandling::Terminal(Box::new(execution)));
         }
 
         let permission_decision = self.coordinator.evaluate(
             Gate::Permission,
-            &permission_input(&effect_digest, &proposal.permission),
+            &permission_input(&effect_digest, self.support.permission_policy()),
         );
-        let permission_decision_id = decision_id("permission", proposal.request.effect_sequence);
+        let permission_decision_id =
+            ledger.decision_id("permission", proposal.request.effect_sequence);
         ledger.protected_effect_decision(
             &permission_decision_id,
             Gate::Permission,
@@ -482,7 +543,8 @@ where
             Gate::ToolTrust,
             &tool_trust_input(&self.support, &proposal.request.capability),
         );
-        let tool_trust_decision_id = decision_id("tool-trust", proposal.request.effect_sequence);
+        let tool_trust_decision_id =
+            ledger.decision_id("tool-trust", proposal.request.effect_sequence);
         ledger.protected_effect_decision(
             &tool_trust_decision_id,
             Gate::ToolTrust,
@@ -515,9 +577,9 @@ where
 
         let runtime_decision = self.coordinator.evaluate(
             Gate::Runtime,
-            &runtime_input(&self.config, &ledger, &proposal, &effect_digest),
+            &runtime_input(&self.support, &self.config, &ledger, &effect_digest),
         );
-        let runtime_decision_id = decision_id("runtime", proposal.request.effect_sequence);
+        let runtime_decision_id = ledger.decision_id("runtime", proposal.request.effect_sequence);
         ledger.protected_effect_decision(
             &runtime_decision_id,
             Gate::Runtime,
@@ -548,57 +610,105 @@ where
                 .map(|execution| EffectHandling::Terminal(Box::new(execution)));
         }
 
-        let workflow_decision = self.coordinator.evaluate(
-            Gate::Workflow,
-            &workflow_mutation_input(
-                &permission_decision,
-                &tool_trust_decision,
-                &runtime_decision,
-            ),
-        );
-        let workflow_decision_id = decision_id("workflow", proposal.request.effect_sequence);
-        ledger.protected_effect_decision(
-            &workflow_decision_id,
-            Gate::Workflow,
-            &effect_digest,
-            workflow_decision.clone(),
-        );
-        if workflow_decision.outcome != Outcome::Allow {
-            let result = self.non_execution_result(
-                &ledger,
-                &proposal.request,
-                &effect_digest,
-                NonExecutionOutcome {
-                    decision: ProtectedEffectDecision {
-                        decision_id: workflow_decision_id,
-                        gate: Gate::Workflow,
-                        effect_request_digest: effect_digest.clone(),
-                        subject_digest: ledger.current_subject.digest.clone(),
-                        decision: workflow_decision.clone(),
-                    },
-                    execution_status: non_execution_status(&workflow_decision),
-                    reason: workflow_decision.code.clone(),
-                    evidence: vec![],
-                },
-            )?;
-            ledger.effect_results.push(result);
-            return self
-                .blocked_from_decision(ledger, workflow_decision)
-                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
-        }
+        let workflow_decision_id =
+            if proposal.request.expected_effect_class == EffectClass::Mutation {
+                let workflow_decision = self.coordinator.evaluate(
+                    Gate::Workflow,
+                    &workflow_mutation_input(
+                        &permission_decision,
+                        &tool_trust_decision,
+                        &runtime_decision,
+                    ),
+                );
+                let workflow_decision_id =
+                    ledger.decision_id("workflow", proposal.request.effect_sequence);
+                ledger.protected_effect_decision(
+                    &workflow_decision_id,
+                    Gate::Workflow,
+                    &effect_digest,
+                    workflow_decision.clone(),
+                );
+                if workflow_decision.outcome != Outcome::Allow {
+                    let result = self.non_execution_result(
+                        &ledger,
+                        &proposal.request,
+                        &effect_digest,
+                        NonExecutionOutcome {
+                            decision: ProtectedEffectDecision {
+                                decision_id: workflow_decision_id,
+                                gate: Gate::Workflow,
+                                effect_request_digest: effect_digest.clone(),
+                                subject_digest: ledger.current_subject.digest.clone(),
+                                decision: workflow_decision.clone(),
+                            },
+                            execution_status: non_execution_status(&workflow_decision),
+                            reason: workflow_decision.code.clone(),
+                            evidence: vec![],
+                        },
+                    )?;
+                    ledger.effect_results.push(result);
+                    return self
+                        .blocked_from_decision(ledger, workflow_decision)
+                        .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+                }
+                Some(workflow_decision_id)
+            } else {
+                None
+            };
 
         let observation = match self.executor.execute(&proposal.request) {
             Ok(observation) => observation,
             Err(error) => {
+                let result = self.executor_error_result(
+                    &ledger,
+                    &proposal.request,
+                    &effect_digest,
+                    ProtectedEffectDecision {
+                        decision_id: permission_decision_id.clone(),
+                        gate: Gate::Permission,
+                        effect_request_digest: effect_digest.clone(),
+                        subject_digest: ledger.current_subject.digest.clone(),
+                        decision: permission_decision.clone(),
+                    },
+                    error,
+                )?;
+                ledger.tool_execution(
+                    &permission_decision_id,
+                    &effect_digest,
+                    &proposal.request.capability.digest,
+                    &result,
+                );
+                if let Some(reason) = ledger.record_effect_usage(&result.body.usage) {
+                    ledger.effect_results.push(result);
+                    return self
+                        .finish(ledger, AgentRunStatus::Blocked, reason)
+                        .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+                }
+                ledger.effect_results.push(result);
                 return self
                     .finish(
                         ledger,
                         AgentRunStatus::Failed,
-                        format!("executor.failed: {}", error.message()),
+                        "protected_effect.unknown_outcome",
                     )
                     .map(|execution| EffectHandling::Terminal(Box::new(execution)));
             }
         };
+        if matches!(
+            observation.execution_status,
+            EffectExecutionStatus::AwaitingAuthority | EffectExecutionStatus::Denied
+        ) {
+            let decision = executor_non_execution_decision(&observation);
+            return self
+                .decline_protected_effect(
+                    ledger,
+                    &proposal.request,
+                    &effect_digest,
+                    Gate::Permission,
+                    decision,
+                )
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
         let effect_result = self.attempt_result(
             &ledger,
             &proposal.request,
@@ -612,27 +722,28 @@ where
             },
             observation,
         )?;
+        ledger.accept_effect_identity(&proposal.request, &effect_digest);
         ledger.tool_execution(
             &permission_decision_id,
             &effect_digest,
             &proposal.request.capability.digest,
             &effect_result,
         );
-        if effect_result.body.execution_status == EffectExecutionStatus::Executed {
-            if let Some(post_subject) = effect_result.body.observed_post_effect_subject.clone() {
-                if proposal.request.expected_effect_class == EffectClass::Mutation {
-                    ledger.mutation(
-                        &workflow_decision_id,
-                        &effect_digest,
-                        &post_subject.digest,
-                        &effect_result.body.evidence,
-                    );
-                    ledger.current_subject = post_subject;
-                }
+        if let Some(post_subject) = effect_result.body.observed_post_effect_subject.clone() {
+            if proposal.request.expected_effect_class == EffectClass::Mutation {
+                let workflow_decision_id = workflow_decision_id
+                    .as_deref()
+                    .expect("mutation effects require a workflow decision");
+                ledger.mutation(
+                    workflow_decision_id,
+                    &effect_digest,
+                    &post_subject.digest,
+                    &effect_result.body.evidence,
+                );
+                ledger.current_subject = post_subject;
             }
         }
-        ledger.add_usage(&effect_result.body.usage);
-        ledger.usage_event();
+        let usage_reason = ledger.record_effect_usage(&effect_result.body.usage);
 
         let mut terminal = match effect_result.body.execution_status {
             EffectExecutionStatus::Executed => None,
@@ -654,10 +765,8 @@ where
                 Some((AgentRunStatus::Failed, "protected_effect.unknown_outcome"))
             }
         };
-        if terminal.is_none()
-            && usage_exceeds_budget(&ledger.usage, &ledger.request.resource_budget)
-        {
-            terminal = Some((AgentRunStatus::Blocked, "runtime.budget_exceeded"));
+        if let Some(reason) = usage_reason {
+            terminal = Some((AgentRunStatus::Blocked, reason));
         }
         ledger.effect_results.push(effect_result);
 
@@ -669,14 +778,87 @@ where
         Ok(EffectHandling::Continue(Box::new(ledger)))
     }
 
+    fn decline_protected_effect(
+        &self,
+        mut ledger: Ledger,
+        request: &ProtectedEffectRequest,
+        effect_digest: &str,
+        gate: Gate,
+        decision: Decision,
+    ) -> Result<AgentRunExecution, RuntimeError> {
+        let decision_id = ledger.decision_id("decline", request.effect_sequence);
+        ledger.protected_effect_decision(&decision_id, gate, effect_digest, decision.clone());
+        let result = self.non_execution_result(
+            &ledger,
+            request,
+            effect_digest,
+            NonExecutionOutcome {
+                decision: ProtectedEffectDecision {
+                    decision_id,
+                    gate,
+                    effect_request_digest: effect_digest.to_string(),
+                    subject_digest: ledger.current_subject.digest.clone(),
+                    decision: decision.clone(),
+                },
+                execution_status: non_execution_status(&decision),
+                reason: decision.code.clone(),
+                evidence: non_execution_evidence(&decision),
+            },
+        )?;
+        ledger.effect_results.push(result);
+        self.blocked_from_decision(ledger, decision)
+    }
+
+    fn executor_error_result(
+        &self,
+        ledger: &Ledger,
+        request: &ProtectedEffectRequest,
+        effect_digest: &str,
+        decision: ProtectedEffectDecision,
+        error: RuntimePortError,
+    ) -> Result<ProtectedEffectResult, RuntimeError> {
+        let body = ProtectedEffectResultBody {
+            schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+            effect_id: request.effect_id.clone(),
+            effect_sequence: request.effect_sequence,
+            run_id: request.run_id.clone(),
+            agent_run_request_digest: request.agent_run_request_digest.clone(),
+            effect_request_digest: effect_digest.to_owned(),
+            observed_pre_effect_subject: ledger.current_subject.clone(),
+            observed_capability: request.capability.clone(),
+            observed_tool_schema_digest: request.tool_schema_digest.clone(),
+            decision,
+            execution_status: EffectExecutionStatus::UnknownOutcome,
+            observed_post_effect_subject: None,
+            exit: None,
+            usage: zero_effect_usage(),
+            executor: Some(self.config.executor_identity.clone()),
+            sandbox_profile: Some(request.sandbox_profile.clone()),
+            reason: Some(format!("executor.failed: {}", error.message())),
+            evidence: vec![
+                runtime_effect_evidence(EffectEvidenceType::Executor, "executor"),
+                runtime_effect_evidence(EffectEvidenceType::Sandbox, "sandbox"),
+                runtime_effect_evidence(EffectEvidenceType::Usage, "usage"),
+                runtime_effect_evidence(EffectEvidenceType::UnknownOutcome, "unknown-outcome"),
+            ],
+        };
+        seal_protected_effect_result(
+            &ledger.request,
+            self.support.contract_support(),
+            request,
+            body,
+        )
+        .map_err(RuntimeError::ProtectedEffectResult)
+    }
+
     fn verify_and_finish(&mut self, mut ledger: Ledger) -> Result<AgentRunExecution, RuntimeError> {
         ledger.transition(AgentRunStatus::Verifying, None);
-        let report = match self.verifier.verify(VerificationContext {
+        let report_observation = match self.verifier.verify(VerificationContext {
             request: &ledger.request,
             current_subject: &ledger.current_subject,
             usage: &ledger.usage,
         }) {
-            Ok(report) => report,
+            Ok(observation) => observation,
             Err(error) => {
                 return self.finish(
                     ledger,
@@ -685,17 +867,46 @@ where
                 );
             }
         };
+        if let Some(reason) = ledger.record_usage(&report_observation.usage) {
+            return self.finish(ledger, AgentRunStatus::Blocked, reason);
+        }
+
+        let report = report_observation.value;
         let verification_decision = self.coordinator.evaluate(
             Gate::Verification,
             &verification_input(&self.config, &ledger.current_subject.digest, &report),
         );
-        ledger.verification(&self.config.implementer_id, &report);
+        if !self.support.trusts_verifier(&report.verifier_id) {
+            return self.finish(
+                ledger,
+                AgentRunStatus::Blocked,
+                "verification.untrusted_verifier",
+            );
+        }
+        let report_is_receipt_safe = verification_report_is_receipt_safe(
+            &ledger.request,
+            &self.config.implementer_id,
+            &report,
+        );
+        if verification_decision.outcome == Outcome::Allow && !report_is_receipt_safe {
+            return self.finish(
+                ledger,
+                AgentRunStatus::Blocked,
+                "verification.invalid_report",
+            );
+        }
+        if report_is_receipt_safe {
+            ledger.verification(&self.config.implementer_id, &report);
+        }
         if verification_decision.outcome != Outcome::Allow {
             return self.finish(ledger, AgentRunStatus::Blocked, verification_decision.code);
         }
         let completion_decision = self.coordinator.evaluate(
             Gate::Workflow,
-            &workflow_completion_input(&verification_decision, ledger.mutation_authorized),
+            &workflow_completion_input(
+                &verification_decision,
+                !ledger.mutation_required || ledger.mutation_authorized,
+            ),
         );
         let completion_decision_id = "decision-completion".to_string();
         ledger.protected_effect_decision(
@@ -827,6 +1038,10 @@ struct Ledger {
     events: Vec<RunEvent>,
     effect_results: Vec<ProtectedEffectResult>,
     effects_seen: u64,
+    effect_ids: BTreeSet<String>,
+    effect_request_digests: BTreeSet<String>,
+    idempotency_keys: BTreeSet<String>,
+    mutation_required: bool,
     mutation_authorized: bool,
 }
 
@@ -841,12 +1056,66 @@ impl Ledger {
             events: Vec::new(),
             effect_results: Vec::new(),
             effects_seen: 0,
+            effect_ids: BTreeSet::new(),
+            effect_request_digests: BTreeSet::new(),
+            idempotency_keys: BTreeSet::new(),
+            mutation_required: false,
             mutation_authorized: false,
         }
     }
 
     fn next_sequence(&self) -> u64 {
         self.events.len() as u64 + 1
+    }
+
+    fn decision_id(&self, prefix: &str, effect_sequence: u64) -> String {
+        format!(
+            "decision-{effect_sequence}-{prefix}-event-{}",
+            self.next_sequence()
+        )
+    }
+
+    fn admission_decision(
+        &self,
+        request: &ProtectedEffectRequest,
+        effect_digest: &str,
+        max_effects: u64,
+    ) -> Option<Decision> {
+        let expected_sequence = self.effects_seen + 1;
+        if request.effect_sequence != expected_sequence {
+            return Some(Decision::block(
+                "runtime.effect_sequence_invalid",
+                &["stop_execution", "record_declined_effect"],
+            ));
+        }
+        if self.effects_seen >= max_effects {
+            return Some(Decision::block(
+                "runtime.max_effects_exhausted",
+                &["stop_execution", "record_declined_effect"],
+            ));
+        }
+        if self.effect_ids.contains(&request.effect_id)
+            || self.effect_request_digests.contains(effect_digest)
+            || self.idempotency_keys.contains(&request.idempotency_key)
+        {
+            return Some(Decision::block(
+                "runtime.duplicate_effect",
+                &["stop_execution", "record_declined_effect"],
+            ));
+        }
+        None
+    }
+
+    fn accept_effect_identity(&mut self, request: &ProtectedEffectRequest, effect_digest: &str) {
+        self.effects_seen += 1;
+        self.effect_ids.insert(request.effect_id.clone());
+        self.effect_request_digests
+            .insert(effect_digest.to_string());
+        self.idempotency_keys
+            .insert(request.idempotency_key.clone());
+        if request.expected_effect_class == EffectClass::Mutation {
+            self.mutation_required = true;
+        }
     }
 
     fn transition(&mut self, to: AgentRunStatus, reason: Option<String>) {
@@ -938,23 +1207,23 @@ impl Ledger {
         });
     }
 
-    fn add_usage(&mut self, effect_usage: &EffectUsage) {
-        self.usage.cost_micros = self
-            .usage
-            .cost_micros
-            .saturating_add(effect_usage.cost_micros);
-        self.usage.elapsed_ms = self
-            .usage
-            .elapsed_ms
-            .saturating_add(effect_usage.elapsed_ms);
-        self.usage.model_tokens = self
-            .usage
-            .model_tokens
-            .saturating_add(effect_usage.model_tokens);
-        self.usage.tool_calls = self
-            .usage
-            .tool_calls
-            .saturating_add(effect_usage.tool_calls);
+    fn record_usage(&mut self, usage: &ResourceUsage) -> Option<&'static str> {
+        let Some(next_usage) = project_resource_usage(&self.usage, usage) else {
+            self.usage = capped_resource_usage(&self.usage, usage);
+            self.usage_event();
+            return Some("runtime.usage_overflow");
+        };
+        self.usage = next_usage;
+        self.usage_event();
+        if usage_exceeds_budget(&self.usage, &self.request.resource_budget) {
+            Some("runtime.budget_exceeded")
+        } else {
+            None
+        }
+    }
+
+    fn record_effect_usage(&mut self, usage: &EffectUsage) -> Option<&'static str> {
+        self.record_usage(&resource_usage_from_effect(usage))
     }
 
     fn usage_event(&mut self) {
@@ -1038,6 +1307,14 @@ fn validate_config(config: &RuntimeConfig, request: &AgentRunRequest) -> Result<
             "implementer_id must not be empty".to_string(),
         ));
     }
+    if config.executor_identity.name.trim().is_empty()
+        || config.executor_identity.version.trim().is_empty()
+        || !is_digest_string(&config.executor_identity.digest)
+    {
+        return Err(RuntimeError::InvalidConfig(
+            "executor_identity must be a valid executor identity".to_string(),
+        ));
+    }
     if config.max_effects == 0 || config.max_effects > MAX_SAFE_INTEGER {
         return Err(RuntimeError::InvalidConfig(
             "max_effects must be between 1 and the JCS safe integer limit".to_string(),
@@ -1067,18 +1344,52 @@ fn validate_config(config: &RuntimeConfig, request: &AgentRunRequest) -> Result<
     Ok(())
 }
 
-fn plan_input(subject: &crate::contracts::Subject, plan: &PlanProposal) -> Value {
+fn validate_support(support: &RuntimeSupport) -> Result<(), RuntimeError> {
+    for (index, approval) in support.runtime_approvals.iter().enumerate() {
+        if !is_digest_string(&approval.subject_digest)
+            || approval
+                .max_cost_micros
+                .is_some_and(|maximum| maximum > MAX_SAFE_INTEGER)
+        {
+            return Err(RuntimeError::InvalidConfig(format!(
+                "runtime_approvals[{index}] must bind a valid digest and safe maximum cost"
+            )));
+        }
+    }
+    for (index, approval) in support.permission_policy.approvals.iter().enumerate() {
+        if !is_digest_string(&approval.subject_digest) {
+            return Err(RuntimeError::InvalidConfig(format!(
+                "permission_policy.approvals[{index}] must bind a valid digest"
+            )));
+        }
+    }
+    if support
+        .trusted_verifier_ids
+        .iter()
+        .any(|verifier| verifier.trim().is_empty())
+    {
+        return Err(RuntimeError::InvalidConfig(
+            "trusted_verifier_ids must not contain empty verifier IDs".to_string(),
+        ));
+    }
+    if !effect_usage_is_safe(&support.protected_effect_usage_estimate) {
+        return Err(RuntimeError::InvalidConfig(
+            "protected_effect_usage_estimate must stay within JCS safe integer bounds".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn plan_input(subject: &crate::contracts::Subject, approval: Option<&ApprovalReference>) -> Value {
     json!({
         "subject_digest": subject.digest,
-        "approval": plan
-            .approval
-            .as_ref()
+        "approval": approval
             .map(approval_reference_value)
             .unwrap_or(Value::Null),
     })
 }
 
-fn permission_input(action_digest: &str, permission: &PermissionInput) -> Value {
+fn permission_input(action_digest: &str, permission: &PermissionPolicy) -> Value {
     let policy_decision = permission
         .policy_decision
         .map(|decision| Value::String(decision.as_str().to_string()))
@@ -1090,8 +1401,7 @@ fn permission_input(action_digest: &str, permission: &PermissionInput) -> Value 
         "risk_tags": permission.risk_tags,
         "wrapper_chain": permission.wrapper_chain,
         "approval": permission
-            .approval
-            .as_ref()
+            .approval_for(action_digest)
             .map(gate_approval_value)
             .unwrap_or(Value::Null),
     })
@@ -1115,22 +1425,26 @@ fn tool_trust_input(support: &RuntimeSupport, capability: &CapabilityIdentity) -
 }
 
 fn runtime_input(
+    support: &RuntimeSupport,
     config: &RuntimeConfig,
     ledger: &Ledger,
-    proposal: &ProtectedEffectProposal,
     effect_digest: &str,
 ) -> Value {
+    let estimate = support.protected_effect_usage_estimate();
     json!({
         "action_digest": effect_digest,
         "usage_status": "known",
         "current_cost_micros": ledger.usage.cost_micros,
-        "estimated_next_cost_micros": proposal.estimated_cost_micros,
+        "estimated_next_cost_micros": estimate.cost_micros,
         "thresholds": {
             "warn_micros": config.budget_thresholds.warn_micros,
             "approval_micros": config.budget_thresholds.approval_micros,
             "hard_stop_micros": config.budget_thresholds.hard_stop_micros,
         },
-        "approval": Value::Null,
+        "approval": support
+            .runtime_approval_for(effect_digest)
+            .map(gate_approval_value)
+            .unwrap_or(Value::Null),
     })
 }
 
@@ -1227,6 +1541,201 @@ fn non_execution_status(decision: &Decision) -> EffectExecutionStatus {
     }
 }
 
+fn plan_approval_for<'a>(
+    request: &'a AgentRunRequest,
+    subject_digest: &str,
+) -> Option<&'a ApprovalReference> {
+    request
+        .approval_context
+        .iter()
+        .find(|approval| approval.subject_digest == subject_digest)
+}
+
+fn sanitize_cancellation(cancellation: Cancellation) -> Cancellation {
+    let reason = if cancellation.reason.trim().is_empty() {
+        "runtime.interrupted".to_string()
+    } else {
+        cancellation.reason
+    };
+    let actor_id = cancellation
+        .actor_id
+        .filter(|actor| !actor.trim().is_empty());
+    let evidence = if evidence_reference_is_valid(&cancellation.evidence)
+        && cancellation.evidence.evidence_type == EvidenceType::Interruption
+    {
+        cancellation.evidence
+    } else {
+        EvidenceReference {
+            evidence_type: EvidenceType::Interruption,
+            digest: digest_bytes(format!("gaap:runtime/interruption:{reason}").as_bytes()),
+            locator: Some("gaap:runtime/interruption".to_string()),
+        }
+    };
+
+    Cancellation {
+        actor_id,
+        reason,
+        evidence,
+    }
+}
+
+fn budget_admission_decision(
+    current: &ResourceUsage,
+    budget: &crate::contracts::ResourceBudget,
+    estimate: &EffectUsage,
+) -> Option<Decision> {
+    let estimate = resource_usage_from_effect(estimate);
+    let Some(projected) = project_resource_usage(current, &estimate) else {
+        return Some(Decision::block(
+            "runtime.invalid_budget",
+            &["stop_execution", "request_usage_reconciliation"],
+        ));
+    };
+    if projected.elapsed_ms > budget.max_elapsed_ms
+        || projected.model_tokens > budget.max_model_tokens
+        || projected.tool_calls > budget.max_tool_calls
+    {
+        return Some(Decision::block(
+            "runtime.budget_exceeded",
+            &["stop_execution", "request_usage_reconciliation"],
+        ));
+    }
+    None
+}
+
+fn executor_non_execution_decision(observation: &ExecutorObservation) -> Decision {
+    let code = match observation.execution_status {
+        EffectExecutionStatus::AwaitingAuthority => "executor.awaiting_authority",
+        EffectExecutionStatus::Denied => "executor.denied",
+        _ => "executor.non_execution",
+    };
+    let mut decision = match observation.execution_status {
+        EffectExecutionStatus::AwaitingAuthority => {
+            Decision::ask(code, &["request_executor_authority"])
+        }
+        _ => Decision::block(code, &["stop_execution"]),
+    };
+    if let Some(reason) = observation
+        .reason
+        .as_ref()
+        .filter(|reason| !reason.trim().is_empty())
+    {
+        decision.effects.push(reason.clone());
+    }
+    decision
+}
+
+fn non_execution_evidence(decision: &Decision) -> Vec<EffectEvidenceReference> {
+    if decision.code == "protected_effect.stale_subject" {
+        vec![runtime_effect_evidence(
+            EffectEvidenceType::SubjectObservation,
+            "current-subject",
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn runtime_effect_evidence(
+    evidence_type: EffectEvidenceType,
+    label: &str,
+) -> EffectEvidenceReference {
+    EffectEvidenceReference {
+        evidence_type,
+        digest: digest_bytes(format!("gaap:runtime/effect-evidence:{label}").as_bytes()),
+        locator: Some(format!("gaap:runtime/{label}")),
+    }
+}
+
+fn verification_report_is_receipt_safe(
+    request: &AgentRunRequest,
+    implementer_id: &str,
+    report: &VerificationReport,
+) -> bool {
+    is_digest_string(&report.subject_digest)
+        && !implementer_id.trim().is_empty()
+        && !report.verifier_id.trim().is_empty()
+        && evidence_set_is_valid(&report.evidence)
+        && (report.verdict != VerificationVerdict::Pass
+            || (report.verifier_id != implementer_id
+                && request
+                    .required_verification
+                    .evidence_types
+                    .iter()
+                    .all(|required| {
+                        report
+                            .evidence
+                            .iter()
+                            .any(|evidence| evidence.evidence_type == *required)
+                    })))
+}
+
+fn evidence_set_is_valid(evidence: &[EvidenceReference]) -> bool {
+    !evidence.is_empty() && evidence.iter().all(evidence_reference_is_valid)
+}
+
+fn evidence_reference_is_valid(evidence: &EvidenceReference) -> bool {
+    is_digest_string(&evidence.digest)
+        && evidence
+            .locator
+            .as_ref()
+            .is_none_or(|locator| !locator.trim().is_empty())
+}
+
+fn resource_usage_from_effect(usage: &EffectUsage) -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: usage.cost_micros,
+        elapsed_ms: usage.elapsed_ms,
+        model_tokens: usage.model_tokens,
+        tool_calls: usage.tool_calls,
+    }
+}
+
+fn effect_usage_is_safe(usage: &EffectUsage) -> bool {
+    usage.cost_micros <= MAX_SAFE_INTEGER
+        && usage.elapsed_ms <= MAX_SAFE_INTEGER
+        && usage.model_tokens <= MAX_SAFE_INTEGER
+        && usage.tool_calls <= MAX_SAFE_INTEGER
+}
+
+fn project_resource_usage(current: &ResourceUsage, usage: &ResourceUsage) -> Option<ResourceUsage> {
+    Some(ResourceUsage {
+        cost_micros: checked_usage_sum(current.cost_micros, usage.cost_micros)?,
+        elapsed_ms: checked_usage_sum(current.elapsed_ms, usage.elapsed_ms)?,
+        model_tokens: checked_usage_sum(current.model_tokens, usage.model_tokens)?,
+        tool_calls: checked_usage_sum(current.tool_calls, usage.tool_calls)?,
+    })
+}
+
+fn capped_resource_usage(current: &ResourceUsage, usage: &ResourceUsage) -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: capped_usage_sum(current.cost_micros, usage.cost_micros),
+        elapsed_ms: capped_usage_sum(current.elapsed_ms, usage.elapsed_ms),
+        model_tokens: capped_usage_sum(current.model_tokens, usage.model_tokens),
+        tool_calls: capped_usage_sum(current.tool_calls, usage.tool_calls),
+    }
+}
+
+fn checked_usage_sum(current: u64, usage: u64) -> Option<u64> {
+    current
+        .checked_add(usage)
+        .filter(|total| *total <= MAX_SAFE_INTEGER)
+}
+
+fn capped_usage_sum(current: u64, usage: u64) -> u64 {
+    current.saturating_add(usage).min(MAX_SAFE_INTEGER)
+}
+
+fn is_digest_string(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
 fn zero_effect_usage() -> EffectUsage {
     EffectUsage {
         cost_micros: 0,
@@ -1293,8 +1802,4 @@ fn interruption_evidence(effect_evidence: &[EffectEvidenceReference]) -> Evidenc
 
 fn digest_bytes(bytes: &[u8]) -> String {
     format!("sha256:{:x}", Sha256::digest(bytes))
-}
-
-fn decision_id(prefix: &str, effect_sequence: u64) -> String {
-    format!("decision-{effect_sequence}-{prefix}")
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -699,6 +699,7 @@ where
             EffectExecutionStatus::AwaitingAuthority | EffectExecutionStatus::Denied
         ) {
             let decision = executor_non_execution_decision(&observation);
+            let _usage_reason = ledger.record_effect_usage(&observation.usage);
             return self
                 .decline_protected_effect(
                     ledger,
@@ -766,7 +767,9 @@ where
             }
         };
         if let Some(reason) = usage_reason {
-            terminal = Some((AgentRunStatus::Blocked, reason));
+            if terminal.is_none() {
+                terminal = Some((AgentRunStatus::Blocked, reason));
+            }
         }
         ledger.effect_results.push(effect_result);
 
@@ -980,8 +983,8 @@ where
             observed_post_effect_subject: observation.observed_post_effect_subject,
             exit: observation.exit,
             usage: observation.usage,
-            executor: observation.executor,
-            sandbox_profile: observation.sandbox_profile,
+            executor: Some(self.config.executor_identity.clone()),
+            sandbox_profile: Some(request.sandbox_profile.clone()),
             reason: observation.reason,
             evidence: observation.evidence,
         };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,1300 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::contracts::{
+    AgentRunRequest, AgentRunStatus, ApprovalReference, CapabilityIdentity, ContractError,
+    ContractSupport, EffectClass, EffectEvidenceReference, EffectEvidenceType,
+    EffectExecutionStatus, EffectUsage, EvidenceReference, EvidenceType,
+    PROTECTED_EFFECT_RESULT_SCHEMA, ProtectedEffectDecision, ProtectedEffectRequest,
+    ProtectedEffectResult, ProtectedEffectResultBody, ResourceUsage, RunEvent,
+    TERMINAL_RUN_RECEIPT_SCHEMA, TerminalRunReceipt, TerminalRunReceiptBody, VerificationVerdict,
+    seal_protected_effect_result, seal_terminal_receipt, validate_protected_effect_request,
+    validate_request,
+};
+use crate::{Decision, Gate, Outcome, RunCoordinator};
+
+/// The sealed terminal output of one bounded Agent Run execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentRunExecution {
+    pub receipt: TerminalRunReceipt,
+    pub protected_effect_results: Vec<ProtectedEffectResult>,
+}
+
+/// Runtime-only support metadata that does not alter the frozen v0.1 contracts.
+#[derive(Debug, Clone)]
+pub struct RuntimeSupport {
+    contract_support: ContractSupport,
+    trusted_capabilities: Vec<CapabilityIdentity>,
+}
+
+impl RuntimeSupport {
+    /// Construct runtime support from contract policy support and trusted capabilities.
+    pub fn new(
+        contract_support: ContractSupport,
+        trusted_capabilities: Vec<CapabilityIdentity>,
+    ) -> Self {
+        Self {
+            contract_support,
+            trusted_capabilities,
+        }
+    }
+
+    /// Return the contract support used for request and receipt validation.
+    pub fn contract_support(&self) -> &ContractSupport {
+        &self.contract_support
+    }
+
+    fn trusts_capability(&self, capability: &CapabilityIdentity) -> bool {
+        self.trusted_capabilities
+            .iter()
+            .any(|trusted| trusted == capability)
+    }
+}
+
+/// Cost thresholds evaluated by the runtime gate before execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetThresholds {
+    pub warn_micros: u64,
+    pub approval_micros: u64,
+    pub hard_stop_micros: u64,
+}
+
+/// Configuration for the deterministic in-memory Agent Run engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub implementer_id: String,
+    pub max_effects: u64,
+    pub budget_thresholds: BudgetThresholds,
+}
+
+/// A normalized approval for coordinator gates that are not contract approval references.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GateApproval {
+    pub subject_digest: String,
+    pub max_cost_micros: Option<u64>,
+}
+
+/// The adapter's approved plan proposal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanProposal {
+    pub plan_digest: String,
+    pub approval: Option<ApprovalReference>,
+}
+
+/// A policy decision supplied by a deterministic policy adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyDecision {
+    Allow,
+    Ask,
+    Deny,
+}
+
+impl PolicyDecision {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Ask => "ask",
+            Self::Deny => "deny",
+        }
+    }
+}
+
+/// Permission gate input attached to one proposed protected effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionInput {
+    pub policy_decision: Option<PolicyDecision>,
+    pub risk_tags: Vec<String>,
+    pub wrapper_chain: Vec<String>,
+    pub approval: Option<GateApproval>,
+}
+
+/// One protected effect proposal from the agent adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtectedEffectProposal {
+    pub request: ProtectedEffectRequest,
+    pub permission: PermissionInput,
+    pub estimated_cost_micros: u64,
+}
+
+/// A bounded next step from the agent adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentStep {
+    ProtectedEffect(Box<ProtectedEffectProposal>),
+    Finish,
+    Cancel(Cancellation),
+}
+
+/// Adapter-provided cancellation state for an interrupted run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cancellation {
+    pub actor_id: Option<String>,
+    pub reason: String,
+    pub evidence: EvidenceReference,
+}
+
+/// Deterministic execution observation returned by the executor port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutorObservation {
+    pub execution_status: EffectExecutionStatus,
+    pub observed_post_effect_subject: Option<crate::contracts::Subject>,
+    pub exit: Option<crate::contracts::EffectExit>,
+    pub usage: EffectUsage,
+    pub executor: Option<crate::contracts::ExecutorIdentity>,
+    pub sandbox_profile: Option<crate::contracts::SandboxProfileIdentity>,
+    pub reason: Option<String>,
+    pub evidence: Vec<EffectEvidenceReference>,
+}
+
+/// Independent verification report returned by the verifier port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationReport {
+    pub subject_digest: String,
+    pub verifier_id: String,
+    pub verdict: VerificationVerdict,
+    pub evidence: Vec<EvidenceReference>,
+}
+
+/// Read-only context supplied when asking the agent adapter for another effect.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentRunContext<'a> {
+    pub current_subject: &'a crate::contracts::Subject,
+    pub usage: &'a ResourceUsage,
+    pub effects_seen: u64,
+}
+
+/// Read-only context supplied when requesting independent verification.
+#[derive(Debug, Clone, Copy)]
+pub struct VerificationContext<'a> {
+    pub request: &'a AgentRunRequest,
+    pub current_subject: &'a crate::contracts::Subject,
+    pub usage: &'a ResourceUsage,
+}
+
+/// Narrow adapter that can propose a plan and the next bounded effect.
+pub trait AgentAdapter {
+    fn plan(&mut self, request: &AgentRunRequest) -> Result<PlanProposal, RuntimePortError>;
+
+    fn next_effect(&mut self, context: AgentRunContext<'_>) -> Result<AgentStep, RuntimePortError>;
+}
+
+/// Narrow executor port used only after all mutation gates allow.
+pub trait ExecutorPort {
+    fn execute(
+        &mut self,
+        request: &ProtectedEffectRequest,
+    ) -> Result<ExecutorObservation, RuntimePortError>;
+}
+
+/// Narrow verifier port used before the terminal completion decision.
+pub trait VerifierPort {
+    fn verify(
+        &mut self,
+        context: VerificationContext<'_>,
+    ) -> Result<VerificationReport, RuntimePortError>;
+}
+
+/// Failure returned by a runtime adapter port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimePortError {
+    message: String,
+}
+
+impl RuntimePortError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for RuntimePortError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for RuntimePortError {}
+
+/// Runtime-level failures before a terminal receipt can be sealed.
+#[derive(Debug)]
+pub enum RuntimeError {
+    Contract(ContractError),
+    InvalidConfig(String),
+    Receipt(ContractError),
+    ProtectedEffectResult(ContractError),
+}
+
+impl Display for RuntimeError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Contract(error) => write!(formatter, "contract validation failed: {error}"),
+            Self::InvalidConfig(message) => write!(formatter, "invalid runtime config: {message}"),
+            Self::Receipt(error) => write!(formatter, "could not seal terminal receipt: {error}"),
+            Self::ProtectedEffectResult(error) => {
+                write!(formatter, "could not seal protected effect result: {error}")
+            }
+        }
+    }
+}
+
+impl Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Contract(error) | Self::Receipt(error) | Self::ProtectedEffectResult(error) => {
+                Some(error)
+            }
+            Self::InvalidConfig(_) => None,
+        }
+    }
+}
+
+enum EffectHandling {
+    Continue(Box<Ledger>),
+    Terminal(Box<AgentRunExecution>),
+}
+
+struct NonExecutionOutcome {
+    decision: ProtectedEffectDecision,
+    execution_status: EffectExecutionStatus,
+    reason: String,
+    evidence: Vec<EffectEvidenceReference>,
+}
+
+/// Deterministic in-memory engine for one bounded Agent Run.
+pub struct AgentRunEngine<A, E, V> {
+    support: RuntimeSupport,
+    config: RuntimeConfig,
+    coordinator: RunCoordinator,
+    agent: A,
+    executor: E,
+    verifier: V,
+}
+
+impl<A, E, V> AgentRunEngine<A, E, V>
+where
+    A: AgentAdapter,
+    E: ExecutorPort,
+    V: VerifierPort,
+{
+    pub fn new(
+        support: RuntimeSupport,
+        config: RuntimeConfig,
+        agent: A,
+        executor: E,
+        verifier: V,
+    ) -> Self {
+        Self {
+            support,
+            config,
+            coordinator: RunCoordinator,
+            agent,
+            executor,
+            verifier,
+        }
+    }
+
+    pub fn run(&mut self, request: AgentRunRequest) -> Result<AgentRunExecution, RuntimeError> {
+        validate_config(&self.config, &request)?;
+        let request_digest = validate_request(&request, self.support.contract_support())
+            .map_err(RuntimeError::Contract)?;
+        let mut ledger = Ledger::new(request.clone(), request_digest);
+
+        ledger.transition(AgentRunStatus::Planning, None);
+        let plan = match self.agent.plan(&request) {
+            Ok(plan) => plan,
+            Err(error) => {
+                return self.finish(
+                    ledger,
+                    AgentRunStatus::Failed,
+                    format!("adapter.plan_failed: {}", error.message()),
+                );
+            }
+        };
+
+        ledger.plan_recorded(plan.plan_digest.clone());
+        if let Some(approval) = plan.approval.clone() {
+            ledger.approval_recorded(approval);
+        }
+        let plan_decision = self
+            .coordinator
+            .evaluate(Gate::Plan, &plan_input(&ledger.current_subject, &plan));
+        if plan_decision.outcome != Outcome::Allow {
+            return self.finish(ledger, AgentRunStatus::Blocked, plan_decision.code);
+        }
+
+        ledger.transition(AgentRunStatus::Executing, None);
+        loop {
+            let step = match self.agent.next_effect(AgentRunContext {
+                current_subject: &ledger.current_subject,
+                usage: &ledger.usage,
+                effects_seen: ledger.effects_seen,
+            }) {
+                Ok(step) => step,
+                Err(error) => {
+                    return self.finish(
+                        ledger,
+                        AgentRunStatus::Failed,
+                        format!("adapter.next_effect_failed: {}", error.message()),
+                    );
+                }
+            };
+
+            match step {
+                AgentStep::ProtectedEffect(proposal) => {
+                    if ledger.effects_seen >= self.config.max_effects {
+                        return self.finish(
+                            ledger,
+                            AgentRunStatus::Blocked,
+                            "runtime.max_effects_exhausted",
+                        );
+                    }
+                    match self.handle_protected_effect(ledger, *proposal)? {
+                        EffectHandling::Continue(next) => {
+                            ledger = *next;
+                        }
+                        EffectHandling::Terminal(execution) => {
+                            return Ok(*execution);
+                        }
+                    }
+                }
+                AgentStep::Finish => {
+                    return self.verify_and_finish(ledger);
+                }
+                AgentStep::Cancel(cancellation) => {
+                    ledger.interruption(cancellation);
+                    return self.finish(ledger, AgentRunStatus::Interrupted, "runtime.interrupted");
+                }
+            }
+        }
+    }
+
+    fn handle_protected_effect(
+        &mut self,
+        mut ledger: Ledger,
+        proposal: ProtectedEffectProposal,
+    ) -> Result<EffectHandling, RuntimeError> {
+        ledger.effects_seen += 1;
+        let effect_digest = match validate_protected_effect_request(
+            &ledger.request,
+            self.support.contract_support(),
+            &proposal.request,
+        ) {
+            Ok(digest) => digest,
+            Err(error) => {
+                return self
+                    .finish(
+                        ledger,
+                        AgentRunStatus::Failed,
+                        format!("protected_effect.invalid_request: {}", error.message()),
+                    )
+                    .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+            }
+        };
+
+        if proposal.request.subject != ledger.current_subject {
+            let decision = Decision {
+                outcome: Outcome::Block,
+                code: "protected_effect.stale_subject".to_string(),
+                effects: vec!["stop_action".to_string()],
+            };
+            let decision_id = decision_id("subject", proposal.request.effect_sequence);
+            ledger.protected_effect_decision(
+                &decision_id,
+                Gate::Permission,
+                &effect_digest,
+                decision.clone(),
+            );
+            let result = self.non_execution_result(
+                &ledger,
+                &proposal.request,
+                &effect_digest,
+                NonExecutionOutcome {
+                    decision: ProtectedEffectDecision {
+                        decision_id,
+                        gate: Gate::Permission,
+                        effect_request_digest: effect_digest.clone(),
+                        subject_digest: ledger.current_subject.digest.clone(),
+                        decision,
+                    },
+                    execution_status: EffectExecutionStatus::Denied,
+                    reason: "protected_effect.stale_subject".to_string(),
+                    evidence: vec![EffectEvidenceReference {
+                        evidence_type: EffectEvidenceType::SubjectObservation,
+                        digest: digest_bytes(ledger.current_subject.digest.as_bytes()),
+                        locator: Some("gaap:runtime/current-subject".to_string()),
+                    }],
+                },
+            )?;
+            ledger.effect_results.push(result);
+            return self
+                .finish(
+                    ledger,
+                    AgentRunStatus::Blocked,
+                    "protected_effect.stale_subject",
+                )
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
+        let permission_decision = self.coordinator.evaluate(
+            Gate::Permission,
+            &permission_input(&effect_digest, &proposal.permission),
+        );
+        let permission_decision_id = decision_id("permission", proposal.request.effect_sequence);
+        ledger.protected_effect_decision(
+            &permission_decision_id,
+            Gate::Permission,
+            &effect_digest,
+            permission_decision.clone(),
+        );
+        if permission_decision.outcome != Outcome::Allow {
+            let status = non_execution_status(&permission_decision);
+            let result = self.non_execution_result(
+                &ledger,
+                &proposal.request,
+                &effect_digest,
+                NonExecutionOutcome {
+                    decision: ProtectedEffectDecision {
+                        decision_id: permission_decision_id,
+                        gate: Gate::Permission,
+                        effect_request_digest: effect_digest.clone(),
+                        subject_digest: ledger.current_subject.digest.clone(),
+                        decision: permission_decision.clone(),
+                    },
+                    execution_status: status,
+                    reason: permission_decision.code.clone(),
+                    evidence: vec![],
+                },
+            )?;
+            ledger.effect_results.push(result);
+            return self
+                .blocked_from_decision(ledger, permission_decision)
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
+        let tool_trust_decision = self.coordinator.evaluate(
+            Gate::ToolTrust,
+            &tool_trust_input(&self.support, &proposal.request.capability),
+        );
+        let tool_trust_decision_id = decision_id("tool-trust", proposal.request.effect_sequence);
+        ledger.protected_effect_decision(
+            &tool_trust_decision_id,
+            Gate::ToolTrust,
+            &effect_digest,
+            tool_trust_decision.clone(),
+        );
+        if tool_trust_decision.outcome != Outcome::Allow {
+            let result = self.non_execution_result(
+                &ledger,
+                &proposal.request,
+                &effect_digest,
+                NonExecutionOutcome {
+                    decision: ProtectedEffectDecision {
+                        decision_id: tool_trust_decision_id,
+                        gate: Gate::ToolTrust,
+                        effect_request_digest: effect_digest.clone(),
+                        subject_digest: ledger.current_subject.digest.clone(),
+                        decision: tool_trust_decision.clone(),
+                    },
+                    execution_status: non_execution_status(&tool_trust_decision),
+                    reason: tool_trust_decision.code.clone(),
+                    evidence: vec![],
+                },
+            )?;
+            ledger.effect_results.push(result);
+            return self
+                .blocked_from_decision(ledger, tool_trust_decision)
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
+        let runtime_decision = self.coordinator.evaluate(
+            Gate::Runtime,
+            &runtime_input(&self.config, &ledger, &proposal, &effect_digest),
+        );
+        let runtime_decision_id = decision_id("runtime", proposal.request.effect_sequence);
+        ledger.protected_effect_decision(
+            &runtime_decision_id,
+            Gate::Runtime,
+            &effect_digest,
+            runtime_decision.clone(),
+        );
+        if runtime_decision.outcome != Outcome::Allow {
+            let result = self.non_execution_result(
+                &ledger,
+                &proposal.request,
+                &effect_digest,
+                NonExecutionOutcome {
+                    decision: ProtectedEffectDecision {
+                        decision_id: runtime_decision_id,
+                        gate: Gate::Runtime,
+                        effect_request_digest: effect_digest.clone(),
+                        subject_digest: ledger.current_subject.digest.clone(),
+                        decision: runtime_decision.clone(),
+                    },
+                    execution_status: non_execution_status(&runtime_decision),
+                    reason: runtime_decision.code.clone(),
+                    evidence: vec![],
+                },
+            )?;
+            ledger.effect_results.push(result);
+            return self
+                .blocked_from_decision(ledger, runtime_decision)
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
+        let workflow_decision = self.coordinator.evaluate(
+            Gate::Workflow,
+            &workflow_mutation_input(
+                &permission_decision,
+                &tool_trust_decision,
+                &runtime_decision,
+            ),
+        );
+        let workflow_decision_id = decision_id("workflow", proposal.request.effect_sequence);
+        ledger.protected_effect_decision(
+            &workflow_decision_id,
+            Gate::Workflow,
+            &effect_digest,
+            workflow_decision.clone(),
+        );
+        if workflow_decision.outcome != Outcome::Allow {
+            let result = self.non_execution_result(
+                &ledger,
+                &proposal.request,
+                &effect_digest,
+                NonExecutionOutcome {
+                    decision: ProtectedEffectDecision {
+                        decision_id: workflow_decision_id,
+                        gate: Gate::Workflow,
+                        effect_request_digest: effect_digest.clone(),
+                        subject_digest: ledger.current_subject.digest.clone(),
+                        decision: workflow_decision.clone(),
+                    },
+                    execution_status: non_execution_status(&workflow_decision),
+                    reason: workflow_decision.code.clone(),
+                    evidence: vec![],
+                },
+            )?;
+            ledger.effect_results.push(result);
+            return self
+                .blocked_from_decision(ledger, workflow_decision)
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+
+        let observation = match self.executor.execute(&proposal.request) {
+            Ok(observation) => observation,
+            Err(error) => {
+                return self
+                    .finish(
+                        ledger,
+                        AgentRunStatus::Failed,
+                        format!("executor.failed: {}", error.message()),
+                    )
+                    .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+            }
+        };
+        let effect_result = self.attempt_result(
+            &ledger,
+            &proposal.request,
+            &effect_digest,
+            ProtectedEffectDecision {
+                decision_id: permission_decision_id.clone(),
+                gate: Gate::Permission,
+                effect_request_digest: effect_digest.clone(),
+                subject_digest: ledger.current_subject.digest.clone(),
+                decision: permission_decision,
+            },
+            observation,
+        )?;
+        ledger.tool_execution(
+            &permission_decision_id,
+            &effect_digest,
+            &proposal.request.capability.digest,
+            &effect_result,
+        );
+        if effect_result.body.execution_status == EffectExecutionStatus::Executed {
+            if let Some(post_subject) = effect_result.body.observed_post_effect_subject.clone() {
+                if proposal.request.expected_effect_class == EffectClass::Mutation {
+                    ledger.mutation(
+                        &workflow_decision_id,
+                        &effect_digest,
+                        &post_subject.digest,
+                        &effect_result.body.evidence,
+                    );
+                    ledger.current_subject = post_subject;
+                }
+            }
+        }
+        ledger.add_usage(&effect_result.body.usage);
+        ledger.usage_event();
+
+        let mut terminal = match effect_result.body.execution_status {
+            EffectExecutionStatus::Executed => None,
+            EffectExecutionStatus::AwaitingAuthority => Some((
+                AgentRunStatus::Blocked,
+                "protected_effect.awaiting_authority",
+            )),
+            EffectExecutionStatus::Denied => {
+                Some((AgentRunStatus::Blocked, "protected_effect.denied"))
+            }
+            EffectExecutionStatus::Failed => {
+                Some((AgentRunStatus::Failed, "protected_effect.failed"))
+            }
+            EffectExecutionStatus::Interrupted => {
+                ledger.interruption_from_effect(&effect_result);
+                Some((AgentRunStatus::Interrupted, "protected_effect.interrupted"))
+            }
+            EffectExecutionStatus::UnknownOutcome => {
+                Some((AgentRunStatus::Failed, "protected_effect.unknown_outcome"))
+            }
+        };
+        if terminal.is_none()
+            && usage_exceeds_budget(&ledger.usage, &ledger.request.resource_budget)
+        {
+            terminal = Some((AgentRunStatus::Blocked, "runtime.budget_exceeded"));
+        }
+        ledger.effect_results.push(effect_result);
+
+        if let Some((status, reason)) = terminal {
+            return self
+                .finish(ledger, status, reason)
+                .map(|execution| EffectHandling::Terminal(Box::new(execution)));
+        }
+        Ok(EffectHandling::Continue(Box::new(ledger)))
+    }
+
+    fn verify_and_finish(&mut self, mut ledger: Ledger) -> Result<AgentRunExecution, RuntimeError> {
+        ledger.transition(AgentRunStatus::Verifying, None);
+        let report = match self.verifier.verify(VerificationContext {
+            request: &ledger.request,
+            current_subject: &ledger.current_subject,
+            usage: &ledger.usage,
+        }) {
+            Ok(report) => report,
+            Err(error) => {
+                return self.finish(
+                    ledger,
+                    AgentRunStatus::Failed,
+                    format!("verifier.failed: {}", error.message()),
+                );
+            }
+        };
+        let verification_decision = self.coordinator.evaluate(
+            Gate::Verification,
+            &verification_input(&self.config, &ledger.current_subject.digest, &report),
+        );
+        ledger.verification(&self.config.implementer_id, &report);
+        if verification_decision.outcome != Outcome::Allow {
+            return self.finish(ledger, AgentRunStatus::Blocked, verification_decision.code);
+        }
+        let completion_decision = self.coordinator.evaluate(
+            Gate::Workflow,
+            &workflow_completion_input(&verification_decision, ledger.mutation_authorized),
+        );
+        let completion_decision_id = "decision-completion".to_string();
+        ledger.protected_effect_decision(
+            &completion_decision_id,
+            Gate::Workflow,
+            &ledger.current_subject.digest.clone(),
+            completion_decision.clone(),
+        );
+        if completion_decision.outcome != Outcome::Allow {
+            return self.finish(ledger, AgentRunStatus::Blocked, completion_decision.code);
+        }
+        self.finish(ledger, AgentRunStatus::Completed, completion_decision.code)
+    }
+
+    fn non_execution_result(
+        &self,
+        ledger: &Ledger,
+        request: &ProtectedEffectRequest,
+        effect_digest: &str,
+        outcome: NonExecutionOutcome,
+    ) -> Result<ProtectedEffectResult, RuntimeError> {
+        let body = ProtectedEffectResultBody {
+            schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+            effect_id: request.effect_id.clone(),
+            effect_sequence: request.effect_sequence,
+            run_id: request.run_id.clone(),
+            agent_run_request_digest: request.agent_run_request_digest.clone(),
+            effect_request_digest: effect_digest.to_owned(),
+            observed_pre_effect_subject: ledger.current_subject.clone(),
+            observed_capability: request.capability.clone(),
+            observed_tool_schema_digest: request.tool_schema_digest.clone(),
+            decision: outcome.decision,
+            execution_status: outcome.execution_status,
+            observed_post_effect_subject: None,
+            exit: None,
+            usage: zero_effect_usage(),
+            executor: None,
+            sandbox_profile: None,
+            reason: Some(outcome.reason),
+            evidence: outcome.evidence,
+        };
+        seal_protected_effect_result(
+            &ledger.request,
+            self.support.contract_support(),
+            request,
+            body,
+        )
+        .map_err(RuntimeError::ProtectedEffectResult)
+    }
+
+    fn attempt_result(
+        &self,
+        ledger: &Ledger,
+        request: &ProtectedEffectRequest,
+        effect_digest: &str,
+        decision: ProtectedEffectDecision,
+        observation: ExecutorObservation,
+    ) -> Result<ProtectedEffectResult, RuntimeError> {
+        let body = ProtectedEffectResultBody {
+            schema_version: PROTECTED_EFFECT_RESULT_SCHEMA.to_owned(),
+            effect_id: request.effect_id.clone(),
+            effect_sequence: request.effect_sequence,
+            run_id: request.run_id.clone(),
+            agent_run_request_digest: request.agent_run_request_digest.clone(),
+            effect_request_digest: effect_digest.to_owned(),
+            observed_pre_effect_subject: ledger.current_subject.clone(),
+            observed_capability: request.capability.clone(),
+            observed_tool_schema_digest: request.tool_schema_digest.clone(),
+            decision,
+            execution_status: observation.execution_status,
+            observed_post_effect_subject: observation.observed_post_effect_subject,
+            exit: observation.exit,
+            usage: observation.usage,
+            executor: observation.executor,
+            sandbox_profile: observation.sandbox_profile,
+            reason: observation.reason,
+            evidence: observation.evidence,
+        };
+        seal_protected_effect_result(
+            &ledger.request,
+            self.support.contract_support(),
+            request,
+            body,
+        )
+        .map_err(RuntimeError::ProtectedEffectResult)
+    }
+
+    fn blocked_from_decision(
+        &self,
+        mut ledger: Ledger,
+        decision: Decision,
+    ) -> Result<AgentRunExecution, RuntimeError> {
+        if decision.outcome == Outcome::Ask {
+            ledger.transition(
+                AgentRunStatus::AwaitingAuthority,
+                Some(decision.code.clone()),
+            );
+        }
+        self.finish(ledger, AgentRunStatus::Blocked, decision.code)
+    }
+
+    fn finish(
+        &self,
+        mut ledger: Ledger,
+        terminal_status: AgentRunStatus,
+        reason: impl Into<String>,
+    ) -> Result<AgentRunExecution, RuntimeError> {
+        let reason = reason.into();
+        ledger.usage_event();
+        ledger.transition(terminal_status, Some(reason.clone()));
+        let request = ledger.request.clone();
+        let protected_effect_results = std::mem::take(&mut ledger.effect_results);
+        let body = ledger.into_receipt_body(terminal_status, reason);
+        let receipt = seal_terminal_receipt(&request, self.support.contract_support(), body)
+            .map_err(RuntimeError::Receipt)?;
+        Ok(AgentRunExecution {
+            receipt,
+            protected_effect_results,
+        })
+    }
+}
+
+struct Ledger {
+    request: AgentRunRequest,
+    request_digest: String,
+    current_subject: crate::contracts::Subject,
+    status: AgentRunStatus,
+    usage: ResourceUsage,
+    events: Vec<RunEvent>,
+    effect_results: Vec<ProtectedEffectResult>,
+    effects_seen: u64,
+    mutation_authorized: bool,
+}
+
+impl Ledger {
+    fn new(request: AgentRunRequest, request_digest: String) -> Self {
+        Self {
+            current_subject: request.subject.clone(),
+            request,
+            request_digest,
+            status: AgentRunStatus::Accepted,
+            usage: zero_resource_usage(),
+            events: Vec::new(),
+            effect_results: Vec::new(),
+            effects_seen: 0,
+            mutation_authorized: false,
+        }
+    }
+
+    fn next_sequence(&self) -> u64 {
+        self.events.len() as u64 + 1
+    }
+
+    fn transition(&mut self, to: AgentRunStatus, reason: Option<String>) {
+        let from = self.status;
+        self.events.push(RunEvent::StatusTransition {
+            sequence: self.next_sequence(),
+            from,
+            to,
+            reason,
+        });
+        self.status = to;
+    }
+
+    fn plan_recorded(&mut self, plan_digest: String) {
+        self.events.push(RunEvent::PlanRecorded {
+            sequence: self.next_sequence(),
+            plan_digest,
+        });
+    }
+
+    fn approval_recorded(&mut self, approval: ApprovalReference) {
+        self.events.push(RunEvent::ApprovalRecorded {
+            sequence: self.next_sequence(),
+            approval,
+        });
+    }
+
+    fn protected_effect_decision(
+        &mut self,
+        decision_id: &str,
+        gate: Gate,
+        protected_effect_digest: &str,
+        decision: Decision,
+    ) {
+        let mutation_authorized = gate == Gate::Workflow
+            && decision.outcome == Outcome::Allow
+            && decision.code == "workflow.mutation_authorized";
+        self.events.push(RunEvent::ProtectedEffectDecision {
+            sequence: self.next_sequence(),
+            decision_id: decision_id.to_string(),
+            gate,
+            protected_effect_digest: protected_effect_digest.to_string(),
+            subject_digest: self.current_subject.digest.clone(),
+            decision,
+        });
+        if mutation_authorized {
+            self.mutation_authorized = true;
+        }
+    }
+
+    fn tool_execution(
+        &mut self,
+        decision_id: &str,
+        protected_effect_digest: &str,
+        capability_digest: &str,
+        result: &ProtectedEffectResult,
+    ) {
+        self.events.push(RunEvent::ToolExecution {
+            sequence: self.next_sequence(),
+            decision_id: decision_id.to_string(),
+            protected_effect_digest: protected_effect_digest.to_string(),
+            action_digest: protected_effect_digest.to_string(),
+            capability_digest: capability_digest.to_string(),
+            evidence: vec![EvidenceReference {
+                evidence_type: EvidenceType::ToolExecution,
+                digest: result.result_digest.clone(),
+                locator: Some(format!(
+                    "gaap:protected-effect-result/{}",
+                    result.body.effect_id
+                )),
+            }],
+        });
+    }
+
+    fn mutation(
+        &mut self,
+        decision_id: &str,
+        protected_effect_digest: &str,
+        after_subject_digest: &str,
+        effect_evidence: &[EffectEvidenceReference],
+    ) {
+        self.events.push(RunEvent::Mutation {
+            sequence: self.next_sequence(),
+            decision_id: decision_id.to_string(),
+            protected_effect_digest: protected_effect_digest.to_string(),
+            before_subject_digest: self.current_subject.digest.clone(),
+            after_subject_digest: after_subject_digest.to_string(),
+            evidence: vec![artifact_evidence(effect_evidence)],
+        });
+    }
+
+    fn add_usage(&mut self, effect_usage: &EffectUsage) {
+        self.usage.cost_micros = self
+            .usage
+            .cost_micros
+            .saturating_add(effect_usage.cost_micros);
+        self.usage.elapsed_ms = self
+            .usage
+            .elapsed_ms
+            .saturating_add(effect_usage.elapsed_ms);
+        self.usage.model_tokens = self
+            .usage
+            .model_tokens
+            .saturating_add(effect_usage.model_tokens);
+        self.usage.tool_calls = self
+            .usage
+            .tool_calls
+            .saturating_add(effect_usage.tool_calls);
+    }
+
+    fn usage_event(&mut self) {
+        if latest_usage(&self.events).as_ref() == Some(&self.usage) {
+            return;
+        }
+        self.events.push(RunEvent::Usage {
+            sequence: self.next_sequence(),
+            usage: self.usage.clone(),
+        });
+    }
+
+    fn verification(&mut self, implementer_id: &str, report: &VerificationReport) {
+        self.events.push(RunEvent::Verification {
+            sequence: self.next_sequence(),
+            subject_digest: report.subject_digest.clone(),
+            implementer_id: implementer_id.to_string(),
+            verifier_id: report.verifier_id.clone(),
+            verdict: report.verdict,
+            evidence: report.evidence.clone(),
+        });
+    }
+
+    fn interruption(&mut self, cancellation: Cancellation) {
+        self.events.push(RunEvent::Interruption {
+            sequence: self.next_sequence(),
+            actor_id: cancellation.actor_id,
+            reason: cancellation.reason,
+            evidence: cancellation.evidence,
+        });
+    }
+
+    fn interruption_from_effect(&mut self, result: &ProtectedEffectResult) {
+        self.events.push(RunEvent::Interruption {
+            sequence: self.next_sequence(),
+            actor_id: result
+                .body
+                .executor
+                .as_ref()
+                .map(|executor| executor.name.clone()),
+            reason: result
+                .body
+                .reason
+                .clone()
+                .unwrap_or_else(|| "protected_effect.interrupted".to_string()),
+            evidence: interruption_evidence(&result.body.evidence),
+        });
+    }
+
+    fn into_receipt_body(
+        self,
+        terminal_status: AgentRunStatus,
+        terminal_reason: String,
+    ) -> TerminalRunReceiptBody {
+        let AgentRunRequest {
+            request_id,
+            run_id,
+            subject,
+            ..
+        } = self.request;
+        TerminalRunReceiptBody {
+            schema_version: TERMINAL_RUN_RECEIPT_SCHEMA.to_owned(),
+            request_id,
+            run_id,
+            request_digest: self.request_digest,
+            initial_subject_digest: subject.digest,
+            resulting_subject_digest: self.current_subject.digest,
+            terminal_status,
+            terminal_reason,
+            usage: self.usage,
+            events: self.events,
+        }
+    }
+}
+
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+fn validate_config(config: &RuntimeConfig, request: &AgentRunRequest) -> Result<(), RuntimeError> {
+    if config.implementer_id.trim().is_empty() {
+        return Err(RuntimeError::InvalidConfig(
+            "implementer_id must not be empty".to_string(),
+        ));
+    }
+    if config.max_effects == 0 || config.max_effects > MAX_SAFE_INTEGER {
+        return Err(RuntimeError::InvalidConfig(
+            "max_effects must be between 1 and the JCS safe integer limit".to_string(),
+        ));
+    }
+    let thresholds = &config.budget_thresholds;
+    if thresholds.warn_micros > MAX_SAFE_INTEGER
+        || thresholds.approval_micros > MAX_SAFE_INTEGER
+        || thresholds.hard_stop_micros > MAX_SAFE_INTEGER
+    {
+        return Err(RuntimeError::InvalidConfig(
+            "budget thresholds must not exceed the JCS safe integer limit".to_string(),
+        ));
+    }
+    if thresholds.warn_micros > thresholds.approval_micros
+        || thresholds.approval_micros > thresholds.hard_stop_micros
+    {
+        return Err(RuntimeError::InvalidConfig(
+            "budget thresholds must be ordered warn <= approval <= hard_stop".to_string(),
+        ));
+    }
+    if thresholds.hard_stop_micros > request.resource_budget.max_cost_micros {
+        return Err(RuntimeError::InvalidConfig(
+            "hard_stop_micros must not exceed the request cost budget".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn plan_input(subject: &crate::contracts::Subject, plan: &PlanProposal) -> Value {
+    json!({
+        "subject_digest": subject.digest,
+        "approval": plan
+            .approval
+            .as_ref()
+            .map(approval_reference_value)
+            .unwrap_or(Value::Null),
+    })
+}
+
+fn permission_input(action_digest: &str, permission: &PermissionInput) -> Value {
+    let policy_decision = permission
+        .policy_decision
+        .map(|decision| Value::String(decision.as_str().to_string()))
+        .unwrap_or(Value::Null);
+
+    json!({
+        "action_digest": action_digest,
+        "policy_decision": policy_decision,
+        "risk_tags": permission.risk_tags,
+        "wrapper_chain": permission.wrapper_chain,
+        "approval": permission
+            .approval
+            .as_ref()
+            .map(gate_approval_value)
+            .unwrap_or(Value::Null),
+    })
+}
+
+fn tool_trust_input(support: &RuntimeSupport, capability: &CapabilityIdentity) -> Value {
+    let approval = if support.trusts_capability(capability) {
+        json!({
+            "status": "approved",
+            "subject_digest": capability.digest,
+        })
+    } else {
+        Value::Null
+    };
+
+    json!({
+        "capability_name": capability.name,
+        "capability_digest": capability.digest,
+        "approval": approval,
+    })
+}
+
+fn runtime_input(
+    config: &RuntimeConfig,
+    ledger: &Ledger,
+    proposal: &ProtectedEffectProposal,
+    effect_digest: &str,
+) -> Value {
+    json!({
+        "action_digest": effect_digest,
+        "usage_status": "known",
+        "current_cost_micros": ledger.usage.cost_micros,
+        "estimated_next_cost_micros": proposal.estimated_cost_micros,
+        "thresholds": {
+            "warn_micros": config.budget_thresholds.warn_micros,
+            "approval_micros": config.budget_thresholds.approval_micros,
+            "hard_stop_micros": config.budget_thresholds.hard_stop_micros,
+        },
+        "approval": Value::Null,
+    })
+}
+
+fn workflow_mutation_input(
+    permission: &Decision,
+    tool_trust: &Decision,
+    runtime: &Decision,
+) -> Value {
+    json!({
+        "boundary": "mutation",
+        "gate_results": {
+            "plan": "allow",
+            "permission": outcome_name(&permission.outcome),
+            "tool_trust": outcome_name(&tool_trust.outcome),
+            "runtime": outcome_name(&runtime.outcome),
+        }
+    })
+}
+
+fn workflow_completion_input(verification: &Decision, mutation_authorized: bool) -> Value {
+    json!({
+        "boundary": "completion",
+        "mutation_authorized": mutation_authorized,
+        "gate_results": {
+            "verification": outcome_name(&verification.outcome),
+        }
+    })
+}
+
+fn verification_input(
+    config: &RuntimeConfig,
+    subject_digest: &str,
+    report: &VerificationReport,
+) -> Value {
+    let verdict = match report.verdict {
+        VerificationVerdict::Pass => "PASS",
+        VerificationVerdict::Fail => "FAIL",
+    };
+    let evidence = report
+        .evidence
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            json!({
+                "command": format!("verification-evidence-{index}"),
+                "output": item.digest,
+                "result": "PASS",
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "subject_digest": subject_digest,
+        "implementer_id": config.implementer_id,
+        "report": {
+            "verifier_id": report.verifier_id,
+            "subject_digest": report.subject_digest,
+            "verdict": verdict,
+            "evidence": evidence,
+        }
+    })
+}
+
+fn approval_reference_value(approval: &ApprovalReference) -> Value {
+    json!({
+        "status": "approved",
+        "subject_digest": approval.subject_digest,
+    })
+}
+
+fn gate_approval_value(approval: &GateApproval) -> Value {
+    let mut value = json!({
+        "status": "approved",
+        "subject_digest": approval.subject_digest,
+    });
+    if let Some(maximum) = approval.max_cost_micros {
+        value["max_cost_micros"] = json!(maximum);
+    }
+    value
+}
+
+fn outcome_name(outcome: &Outcome) -> &'static str {
+    match outcome {
+        Outcome::Allow => "allow",
+        Outcome::Ask => "ask",
+        Outcome::Block => "block",
+    }
+}
+
+fn non_execution_status(decision: &Decision) -> EffectExecutionStatus {
+    match decision.outcome {
+        Outcome::Ask => EffectExecutionStatus::AwaitingAuthority,
+        Outcome::Allow | Outcome::Block => EffectExecutionStatus::Denied,
+    }
+}
+
+fn zero_effect_usage() -> EffectUsage {
+    EffectUsage {
+        cost_micros: 0,
+        elapsed_ms: 0,
+        model_tokens: 0,
+        tool_calls: 0,
+    }
+}
+
+fn zero_resource_usage() -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: 0,
+        elapsed_ms: 0,
+        model_tokens: 0,
+        tool_calls: 0,
+    }
+}
+
+fn latest_usage(events: &[RunEvent]) -> Option<ResourceUsage> {
+    events.iter().rev().find_map(|event| match event {
+        RunEvent::Usage { usage, .. } => Some(usage.clone()),
+        _ => None,
+    })
+}
+
+fn usage_exceeds_budget(usage: &ResourceUsage, budget: &crate::contracts::ResourceBudget) -> bool {
+    usage.cost_micros > budget.max_cost_micros
+        || usage.elapsed_ms > budget.max_elapsed_ms
+        || usage.model_tokens > budget.max_model_tokens
+        || usage.tool_calls > budget.max_tool_calls
+}
+
+fn artifact_evidence(effect_evidence: &[EffectEvidenceReference]) -> EvidenceReference {
+    effect_evidence
+        .iter()
+        .find(|reference| reference.evidence_type == EffectEvidenceType::Artifact)
+        .map(|reference| EvidenceReference {
+            evidence_type: EvidenceType::Artifact,
+            digest: reference.digest.clone(),
+            locator: reference.locator.clone(),
+        })
+        .unwrap_or_else(|| EvidenceReference {
+            evidence_type: EvidenceType::Artifact,
+            digest: digest_bytes(b"gaap:runtime/missing-artifact-evidence"),
+            locator: Some("gaap:runtime/missing-artifact-evidence".to_string()),
+        })
+}
+
+fn interruption_evidence(effect_evidence: &[EffectEvidenceReference]) -> EvidenceReference {
+    effect_evidence
+        .iter()
+        .find(|reference| reference.evidence_type == EffectEvidenceType::Interruption)
+        .map(|reference| EvidenceReference {
+            evidence_type: EvidenceType::Interruption,
+            digest: reference.digest.clone(),
+            locator: reference.locator.clone(),
+        })
+        .unwrap_or_else(|| EvidenceReference {
+            evidence_type: EvidenceType::Interruption,
+            digest: digest_bytes(b"gaap:runtime/interrupted-effect"),
+            locator: Some("gaap:runtime/interrupted-effect".to_string()),
+        })
+}
+
+fn digest_bytes(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn decision_id(prefix: &str, effect_sequence: u64) -> String {
+    format!("decision-{effect_sequence}-{prefix}")
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,7 +10,7 @@ use crate::contracts::{
     ContractSupport, EffectClass, EffectEvidenceReference, EffectEvidenceType,
     EffectExecutionStatus, EffectUsage, EvidenceReference, EvidenceType, ExecutorIdentity,
     PROTECTED_EFFECT_RESULT_SCHEMA, ProtectedEffectDecision, ProtectedEffectRequest,
-    ProtectedEffectResult, ProtectedEffectResultBody, ResourceUsage, RunEvent,
+    ProtectedEffectResult, ProtectedEffectResultBody, ResourceUsage, RunEvent, Subject,
     TERMINAL_RUN_RECEIPT_SCHEMA, TerminalRunReceipt, TerminalRunReceiptBody, VerificationVerdict,
     seal_protected_effect_result, seal_terminal_receipt, validate_protected_effect_request,
     validate_request,
@@ -1013,13 +1013,10 @@ where
         decision: ProtectedEffectDecision,
         observation: ExecutorObservation,
     ) -> Result<ProtectedEffectResult, RuntimeError> {
-        let mut evidence = observation.evidence;
-        evidence.retain(|reference| {
-            !matches!(
-                reference.evidence_type,
-                EffectEvidenceType::Failure | EffectEvidenceType::Interruption
-            )
-        });
+        let post_subject =
+            valid_observed_post_effect_subject(request, observation.observed_post_effect_subject);
+        let usage = safe_effect_usage(observation.usage);
+        let mut evidence = sanitize_untrusted_sandbox_evidence(observation.evidence);
         ensure_effect_evidence(&mut evidence, EffectEvidenceType::Executor, "executor");
         ensure_effect_evidence(
             &mut evidence,
@@ -1032,7 +1029,7 @@ where
             EffectEvidenceType::UnknownOutcome,
             "untrusted-sandbox-unknown-outcome",
         );
-        if observation.observed_post_effect_subject.is_some() {
+        if post_subject.is_some() {
             ensure_effect_evidence(
                 &mut evidence,
                 EffectEvidenceType::SubjectObservation,
@@ -1071,9 +1068,9 @@ where
             observed_tool_schema_digest: request.tool_schema_digest.clone(),
             decision,
             execution_status: EffectExecutionStatus::UnknownOutcome,
-            observed_post_effect_subject: observation.observed_post_effect_subject,
+            observed_post_effect_subject: post_subject,
             exit: None,
-            usage: observation.usage,
+            usage,
             executor: Some(self.config.executor_identity.clone()),
             sandbox_profile: Some(request.sandbox_profile.clone()),
             reason: Some(reason),
@@ -1788,6 +1785,64 @@ fn ensure_effect_evidence(
         .any(|reference| reference.evidence_type == evidence_type)
     {
         evidence.push(runtime_effect_evidence(evidence_type, label));
+    }
+}
+
+fn sanitize_untrusted_sandbox_evidence(
+    evidence: Vec<EffectEvidenceReference>,
+) -> Vec<EffectEvidenceReference> {
+    let mut seen = BTreeSet::new();
+    let mut sanitized = Vec::new();
+    for reference in evidence {
+        if matches!(
+            reference.evidence_type,
+            EffectEvidenceType::Failure | EffectEvidenceType::Interruption
+        ) || !effect_evidence_reference_is_valid(&reference)
+        {
+            continue;
+        }
+        let key = (
+            reference.evidence_type,
+            reference.digest.clone(),
+            reference.locator.clone(),
+        );
+        if seen.insert(key) {
+            sanitized.push(reference);
+        }
+    }
+    sanitized
+}
+
+fn effect_evidence_reference_is_valid(evidence: &EffectEvidenceReference) -> bool {
+    is_digest_string(&evidence.digest)
+        && evidence
+            .locator
+            .as_ref()
+            .is_none_or(|locator| !locator.trim().is_empty())
+}
+
+fn valid_observed_post_effect_subject(
+    request: &ProtectedEffectRequest,
+    subject: Option<Subject>,
+) -> Option<Subject> {
+    let subject = subject?;
+    if subject.locator.trim().is_empty() || !is_digest_string(&subject.digest) {
+        return None;
+    }
+    if request.expected_effect_class == EffectClass::Observation
+        && subject.digest != request.subject.digest
+    {
+        return None;
+    }
+    Some(subject)
+}
+
+fn safe_effect_usage(usage: EffectUsage) -> EffectUsage {
+    EffectUsage {
+        cost_micros: usage.cost_micros.min(MAX_SAFE_INTEGER),
+        elapsed_ms: usage.elapsed_ms.min(MAX_SAFE_INTEGER),
+        model_tokens: usage.model_tokens.min(MAX_SAFE_INTEGER),
+        tool_calls: usage.tool_calls.min(MAX_SAFE_INTEGER),
     }
 }
 

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -7,16 +7,16 @@ use gaap::contracts::{
     EffectClass, EffectEvidenceReference, EffectEvidenceType, EffectExecutionStatus, EffectUsage,
     EvidenceReference, EvidenceType, ExecutorIdentity, FilesystemAccess, InputMetadataEntry,
     OperationFamily, PROTECTED_EFFECT_REQUEST_SCHEMA, PolicyIdentity, ProtectedEffectRequest,
-    Repeatability, RequestedScope, ResourceBudget, RunEvent, SandboxProfileIdentity, Subject,
-    SubjectKind, TaskSpec, VerificationIndependence, VerificationRequirement, VerificationVerdict,
-    canonical_resource_budget_digest, validate_request, verify_protected_effect_result,
-    verify_terminal_receipt,
+    Repeatability, RequestedScope, ResourceBudget, ResourceUsage, RunEvent, SandboxProfileIdentity,
+    Subject, SubjectKind, TaskSpec, VerificationIndependence, VerificationRequirement,
+    VerificationVerdict, canonical_resource_budget_digest, validate_protected_effect_request,
+    validate_request, verify_protected_effect_result, verify_terminal_receipt,
 };
 use gaap::runtime::{
-    AgentAdapter, AgentRunContext, AgentRunEngine, AgentStep, BudgetThresholds,
-    ExecutorObservation, ExecutorPort, PermissionInput, PlanProposal, PolicyDecision,
-    ProtectedEffectProposal, RuntimeConfig, RuntimePortError, RuntimeSupport, VerificationContext,
-    VerificationReport, VerifierPort,
+    AgentAdapter, AgentRunContext, AgentRunEngine, AgentStep, BudgetThresholds, Cancellation,
+    ExecutorObservation, ExecutorPort, GateApproval, PermissionPolicy, PlanProposal,
+    PolicyDecision, PortObservation, ProtectedEffectProposal, RuntimeConfig, RuntimePortError,
+    RuntimeSupport, VerificationContext, VerificationReport, VerifierPort,
 };
 
 fn digest(byte: u8) -> String {
@@ -108,12 +108,58 @@ fn support() -> ContractSupport {
 }
 
 fn runtime_support(trusted_capabilities: Vec<CapabilityIdentity>) -> RuntimeSupport {
-    RuntimeSupport::new(support(), trusted_capabilities)
+    runtime_support_with_policy_and_estimate(trusted_capabilities, allow_permission(), usage(10))
+}
+
+fn runtime_support_with_policy(
+    trusted_capabilities: Vec<CapabilityIdentity>,
+    permission_policy: PermissionPolicy,
+) -> RuntimeSupport {
+    runtime_support_with_policy_and_estimate(trusted_capabilities, permission_policy, usage(10))
+}
+
+fn runtime_support_with_estimate(
+    trusted_capabilities: Vec<CapabilityIdentity>,
+    estimate: EffectUsage,
+) -> RuntimeSupport {
+    runtime_support_with_policy_and_estimate(trusted_capabilities, allow_permission(), estimate)
+}
+
+fn runtime_support_with_policy_and_estimate(
+    trusted_capabilities: Vec<CapabilityIdentity>,
+    permission_policy: PermissionPolicy,
+    estimate: EffectUsage,
+) -> RuntimeSupport {
+    runtime_support_full(
+        trusted_capabilities,
+        permission_policy,
+        estimate,
+        vec![],
+        vec!["fixture-verifier".to_string()],
+    )
+}
+
+fn runtime_support_full(
+    trusted_capabilities: Vec<CapabilityIdentity>,
+    permission_policy: PermissionPolicy,
+    estimate: EffectUsage,
+    runtime_approvals: Vec<GateApproval>,
+    trusted_verifier_ids: Vec<String>,
+) -> RuntimeSupport {
+    RuntimeSupport::new(
+        support(),
+        trusted_capabilities,
+        permission_policy,
+        estimate,
+        runtime_approvals,
+        trusted_verifier_ids,
+    )
 }
 
 fn config() -> RuntimeConfig {
     RuntimeConfig {
         implementer_id: "runtime-test-engine".to_string(),
+        executor_identity: executor_identity(),
         max_effects: 4,
         budget_thresholds: BudgetThresholds {
             warn_micros: 800_000,
@@ -169,57 +215,52 @@ fn effect_request(
     }
 }
 
-fn allow_permission() -> PermissionInput {
-    PermissionInput {
+fn observation_effect_request(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    effect_sequence: u64,
+) -> ProtectedEffectRequest {
+    let mut effect = effect_request(request, support, effect_sequence);
+    effect.normalized_operation = "filesystem.read".to_string();
+    effect.expected_effect_class = EffectClass::Observation;
+    effect
+}
+
+fn allow_permission() -> PermissionPolicy {
+    PermissionPolicy {
         policy_decision: Some(PolicyDecision::Allow),
         risk_tags: vec![],
         wrapper_chain: vec![],
-        approval: None,
+        approvals: vec![],
     }
 }
 
-fn ask_permission() -> PermissionInput {
-    PermissionInput {
+fn ask_permission() -> PermissionPolicy {
+    PermissionPolicy {
         policy_decision: Some(PolicyDecision::Ask),
         risk_tags: vec![],
         wrapper_chain: vec![],
-        approval: None,
+        approvals: vec![],
     }
 }
 
-fn deny_permission() -> PermissionInput {
-    PermissionInput {
+fn deny_permission() -> PermissionPolicy {
+    PermissionPolicy {
         policy_decision: Some(PolicyDecision::Deny),
         risk_tags: vec![],
         wrapper_chain: vec![],
-        approval: None,
+        approvals: vec![],
     }
 }
 
-fn plan_for(request: &AgentRunRequest) -> PlanProposal {
+fn plan_for(_request: &AgentRunRequest) -> PlanProposal {
     PlanProposal {
         plan_digest: digest(b'6'),
-        approval: Some(approval_for(&request.subject.digest)),
     }
 }
 
-fn proposal(
-    effect: ProtectedEffectRequest,
-    permission: PermissionInput,
-) -> ProtectedEffectProposal {
-    proposal_with_cost(effect, permission, 10)
-}
-
-fn proposal_with_cost(
-    effect: ProtectedEffectRequest,
-    permission: PermissionInput,
-    estimated_cost_micros: u64,
-) -> ProtectedEffectProposal {
-    ProtectedEffectProposal {
-        request: effect,
-        permission,
-        estimated_cost_micros,
-    }
+fn proposal(effect: ProtectedEffectRequest) -> ProtectedEffectProposal {
+    ProtectedEffectProposal { request: effect }
 }
 
 fn executor_identity() -> ExecutorIdentity {
@@ -236,6 +277,24 @@ fn usage(cost: u64) -> EffectUsage {
         elapsed_ms: 10,
         model_tokens: 0,
         tool_calls: 1,
+    }
+}
+
+fn resource_usage(cost: u64) -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: cost,
+        elapsed_ms: 10,
+        model_tokens: 0,
+        tool_calls: 0,
+    }
+}
+
+fn zero_resource_usage() -> ResourceUsage {
+    ResourceUsage {
+        cost_micros: 0,
+        elapsed_ms: 0,
+        model_tokens: 0,
+        tool_calls: 0,
     }
 }
 
@@ -317,6 +376,71 @@ fn interrupted_observation() -> ExecutorObservation {
     }
 }
 
+fn read_only_observation(current_subject: Subject) -> ExecutorObservation {
+    ExecutorObservation {
+        execution_status: EffectExecutionStatus::Executed,
+        observed_post_effect_subject: Some(current_subject),
+        exit: None,
+        usage: usage(10),
+        executor: Some(executor_identity()),
+        sandbox_profile: Some(SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        }),
+        reason: None,
+        evidence: vec![
+            effect_evidence(EffectEvidenceType::Executor, b'a'),
+            effect_evidence(EffectEvidenceType::Sandbox, b'0'),
+            effect_evidence(EffectEvidenceType::SubjectObservation, b'1'),
+            effect_evidence(EffectEvidenceType::Usage, b'3'),
+            effect_evidence(EffectEvidenceType::Output, b'4'),
+        ],
+    }
+}
+
+fn failed_mutation_observation(next_subject: Subject) -> ExecutorObservation {
+    ExecutorObservation {
+        execution_status: EffectExecutionStatus::Failed,
+        observed_post_effect_subject: Some(next_subject),
+        exit: None,
+        usage: usage(10),
+        executor: Some(executor_identity()),
+        sandbox_profile: Some(SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        }),
+        reason: Some("executor returned a known failure".to_string()),
+        evidence: vec![
+            effect_evidence(EffectEvidenceType::Executor, b'a'),
+            effect_evidence(EffectEvidenceType::Artifact, b'b'),
+            effect_evidence(EffectEvidenceType::Sandbox, b'0'),
+            effect_evidence(EffectEvidenceType::SubjectObservation, b'1'),
+            effect_evidence(EffectEvidenceType::Mutation, b'2'),
+            effect_evidence(EffectEvidenceType::Usage, b'3'),
+            effect_evidence(EffectEvidenceType::Failure, b'5'),
+        ],
+    }
+}
+
+fn executor_denied_observation() -> ExecutorObservation {
+    ExecutorObservation {
+        execution_status: EffectExecutionStatus::Denied,
+        observed_post_effect_subject: None,
+        exit: None,
+        usage: usage(10),
+        executor: Some(executor_identity()),
+        sandbox_profile: Some(SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        }),
+        reason: Some("executor policy declined".to_string()),
+        evidence: vec![effect_evidence(EffectEvidenceType::Executor, b'a')],
+    }
+}
+
 fn passing_verification(subject_digest: &str) -> VerificationReport {
     VerificationReport {
         subject_digest: subject_digest.to_string(),
@@ -330,14 +454,27 @@ fn passing_verification(subject_digest: &str) -> VerificationReport {
 }
 
 struct ScriptedAgent {
-    plan: Option<Result<PlanProposal, RuntimePortError>>,
-    steps: VecDeque<Result<AgentStep, RuntimePortError>>,
+    plan: Option<Result<PortObservation<PlanProposal>, RuntimePortError>>,
+    steps: VecDeque<Result<PortObservation<AgentStep>, RuntimePortError>>,
 }
 
 impl ScriptedAgent {
     fn new(
         plan: PlanProposal,
         steps: impl IntoIterator<Item = Result<AgentStep, RuntimePortError>>,
+    ) -> Self {
+        Self::new_with_observations(
+            observe(plan),
+            steps
+                .into_iter()
+                .map(|step| step.map(observe))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn new_with_observations(
+        plan: PortObservation<PlanProposal>,
+        steps: impl IntoIterator<Item = Result<PortObservation<AgentStep>, RuntimePortError>>,
     ) -> Self {
         Self {
             plan: Some(Ok(plan)),
@@ -347,7 +484,10 @@ impl ScriptedAgent {
 }
 
 impl AgentAdapter for ScriptedAgent {
-    fn plan(&mut self, _request: &AgentRunRequest) -> Result<PlanProposal, RuntimePortError> {
+    fn plan(
+        &mut self,
+        _request: &AgentRunRequest,
+    ) -> Result<PortObservation<PlanProposal>, RuntimePortError> {
         self.plan
             .take()
             .expect("agent plan should be called exactly once")
@@ -356,7 +496,7 @@ impl AgentAdapter for ScriptedAgent {
     fn next_effect(
         &mut self,
         _context: AgentRunContext<'_>,
-    ) -> Result<AgentStep, RuntimePortError> {
+    ) -> Result<PortObservation<AgentStep>, RuntimePortError> {
         self.steps
             .pop_front()
             .expect("agent should have another scripted step")
@@ -393,11 +533,15 @@ impl ExecutorPort for RecordingExecutor {
 }
 
 struct ScriptedVerifier {
-    report: Option<Result<VerificationReport, RuntimePortError>>,
+    report: Option<Result<PortObservation<VerificationReport>, RuntimePortError>>,
 }
 
 impl ScriptedVerifier {
     fn new(report: VerificationReport) -> Self {
+        Self::new_with_observation(observe(report))
+    }
+
+    fn new_with_observation(report: PortObservation<VerificationReport>) -> Self {
         Self {
             report: Some(Ok(report)),
         }
@@ -408,11 +552,19 @@ impl VerifierPort for ScriptedVerifier {
     fn verify(
         &mut self,
         _context: VerificationContext<'_>,
-    ) -> Result<VerificationReport, RuntimePortError> {
+    ) -> Result<PortObservation<VerificationReport>, RuntimePortError> {
         self.report
             .take()
             .expect("verifier should be called exactly once")
     }
+}
+
+fn observe<T>(value: T) -> PortObservation<T> {
+    observe_with_usage(value, zero_resource_usage())
+}
+
+fn observe_with_usage<T>(value: T, usage: ResourceUsage) -> PortObservation<T> {
+    PortObservation { value, usage }
 }
 
 fn run_with(
@@ -444,7 +596,6 @@ fn completed_run_returns_a_sealed_terminal_receipt_and_effect_result() {
             [
                 Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                     effect.clone(),
-                    allow_permission(),
                 )))),
                 Ok(AgentStep::Finish),
             ],
@@ -491,12 +642,14 @@ fn ask_decision_terminalizes_without_invoking_executor() {
 
     let execution = run_with(
         run_request.clone(),
-        runtime_support(vec![run_request.requested_capability.clone()]),
+        runtime_support_with_policy(
+            vec![run_request.requested_capability.clone()],
+            ask_permission(),
+        ),
         ScriptedAgent::new(
             plan_for(&run_request),
             [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                 effect.clone(),
-                ask_permission(),
             ))))],
         ),
         RecordingExecutor::new(calls.clone(), []),
@@ -536,12 +689,14 @@ fn denied_effect_terminalizes_without_invoking_executor() {
 
     let execution = run_with(
         run_request.clone(),
-        runtime_support(vec![run_request.requested_capability.clone()]),
+        runtime_support_with_policy(
+            vec![run_request.requested_capability.clone()],
+            deny_permission(),
+        ),
         ScriptedAgent::new(
             plan_for(&run_request),
             [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                 effect.clone(),
-                deny_permission(),
             ))))],
         ),
         RecordingExecutor::new(calls.clone(), []),
@@ -583,7 +738,6 @@ fn untrusted_capability_blocks_before_executor() {
             plan_for(&run_request),
             [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                 effect.clone(),
-                allow_permission(),
             ))))],
         ),
         RecordingExecutor::new(calls.clone(), []),
@@ -623,12 +777,15 @@ fn runtime_hard_stop_blocks_before_executor() {
 
     let execution = run_with(
         run_request.clone(),
-        runtime_support(vec![run_request.requested_capability.clone()]),
+        runtime_support_with_estimate(
+            vec![run_request.requested_capability.clone()],
+            usage(1_000_000),
+        ),
         ScriptedAgent::new(
             plan_for(&run_request),
-            [Ok(AgentStep::ProtectedEffect(Box::new(
-                proposal_with_cost(effect.clone(), allow_permission(), 1_000_000),
-            )))],
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
         ),
         RecordingExecutor::new(calls.clone(), []),
         ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
@@ -670,7 +827,6 @@ fn actual_usage_over_budget_blocks_before_verification() {
             plan_for(&run_request),
             [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                 effect.clone(),
-                allow_permission(),
             ))))],
         ),
         RecordingExecutor::new(
@@ -719,7 +875,6 @@ fn executor_unknown_outcome_is_distinct_from_failure() {
             plan_for(&run_request),
             [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                 effect.clone(),
-                allow_permission(),
             ))))],
         ),
         RecordingExecutor::new(calls.clone(), [Ok(unknown_outcome_observation())]),
@@ -764,7 +919,6 @@ fn interrupted_effect_produces_interrupted_receipt() {
             plan_for(&run_request),
             [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                 effect.clone(),
-                allow_permission(),
             ))))],
         ),
         RecordingExecutor::new(calls.clone(), [Ok(interrupted_observation())]),
@@ -815,7 +969,6 @@ fn stale_verification_blocks_completion() {
             [
                 Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                     effect.clone(),
-                    allow_permission(),
                 )))),
                 Ok(AgentStep::Finish),
             ],
@@ -838,6 +991,499 @@ fn stale_verification_blocks_completion() {
 }
 
 #[test]
+fn finish_without_mutation_can_complete_after_verification() {
+    let run_request = request();
+    let support = support();
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(plan_for(&run_request), [Ok(AgentStep::Finish)]),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Completed
+    );
+    assert!(calls.borrow().is_empty());
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn observation_effect_does_not_manufacture_mutation_authority() {
+    let run_request = request();
+    let support = support();
+    let effect = observation_effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    effect.clone(),
+                )))),
+                Ok(AgentStep::Finish),
+            ],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Ok(read_only_observation(run_request.subject.clone()))],
+        ),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Completed
+    );
+    assert!(
+        !execution
+            .receipt
+            .body
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::Mutation { .. }))
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn invalid_plan_digest_terminalizes_without_poisoning_receipt() {
+    let run_request = request();
+    let support = support();
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            PlanProposal {
+                plan_digest: "not-a-digest".to_string(),
+            },
+            [],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "plan.invalid_digest"
+    );
+    assert!(
+        !execution
+            .receipt
+            .body
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::PlanRecorded { .. }))
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn invalid_cancellation_is_sanitized_for_interrupted_receipt() {
+    let run_request = request();
+    let support = support();
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::Cancel(Cancellation {
+                actor_id: Some("".to_string()),
+                reason: "".to_string(),
+                evidence: evidence(EvidenceType::Artifact, b'a'),
+            }))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Interrupted
+    );
+    assert!(execution.receipt.body.events.iter().any(|event| matches!(
+        event,
+        RunEvent::Interruption {
+            actor_id: None,
+            reason,
+            evidence,
+            ..
+        } if reason == "runtime.interrupted"
+            && evidence.evidence_type == EvidenceType::Interruption
+    )));
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn runtime_approval_from_support_allows_overage_threshold() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let effect_digest = validate_protected_effect_request(&run_request, &support, &effect)
+        .expect("effect should validate");
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support_full(
+            vec![run_request.requested_capability.clone()],
+            allow_permission(),
+            usage(900_000),
+            vec![GateApproval {
+                subject_digest: effect_digest,
+                max_cost_micros: Some(900_000),
+            }],
+            vec!["fixture-verifier".to_string()],
+        ),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    effect.clone(),
+                )))),
+                Ok(AgentStep::Finish),
+            ],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Ok(executed_observation(post_subject.clone()))],
+        ),
+        ScriptedVerifier::new(passing_verification(&post_subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Completed
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn duplicate_effect_sequence_blocks_before_executor() {
+    let run_request = request();
+    let support = support();
+    let first = effect_request(&run_request, &support, 1);
+    let duplicate = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    first.clone(),
+                )))),
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    duplicate.clone(),
+                )))),
+            ],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Ok(executed_observation(run_request.subject.clone()))],
+        ),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "runtime.effect_sequence_invalid"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(execution.protected_effect_results.len(), 2);
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &duplicate,
+        &execution.protected_effect_results[1],
+    )
+    .unwrap();
+}
+
+#[test]
+fn trusted_non_cost_estimate_blocks_before_executor() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut estimate = usage(10);
+    estimate.elapsed_ms = 60_001;
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support_with_estimate(vec![run_request.requested_capability.clone()], estimate),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "runtime.budget_exceeded"
+    );
+    assert!(calls.borrow().is_empty());
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn agent_step_usage_over_budget_blocks_before_executor() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new_with_observations(
+            observe(plan_for(&run_request)),
+            [Ok(observe_with_usage(
+                AgentStep::ProtectedEffect(Box::new(proposal(effect))),
+                resource_usage(1_000_001),
+            ))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "runtime.budget_exceeded"
+    );
+    assert!(calls.borrow().is_empty());
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn executor_denial_is_normalized_to_non_execution_result() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(executor_denied_observation())]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::Denied
+    );
+    assert!(
+        execution.protected_effect_results[0]
+            .body
+            .executor
+            .is_none()
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn executor_error_records_unknown_outcome_result() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Err(RuntimePortError::new("lost executor response"))],
+        ),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.unknown_outcome"
+    );
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::UnknownOutcome
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn failed_mutation_with_observed_subject_updates_receipt_subject() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Ok(failed_mutation_observation(post_subject.clone()))],
+        ),
+        ScriptedVerifier::new(passing_verification(&post_subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.resulting_subject_digest,
+        post_subject.digest
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn rejected_self_verification_does_not_poison_receipt() {
+    let run_request = request();
+    let support = support();
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut report = passing_verification(&run_request.subject.digest);
+    report.verifier_id = "runtime-test-engine".to_string();
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support_full(
+            vec![run_request.requested_capability.clone()],
+            allow_permission(),
+            usage(10),
+            vec![],
+            vec!["runtime-test-engine".to_string()],
+        ),
+        ScriptedAgent::new(plan_for(&run_request), [Ok(AgentStep::Finish)]),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(report),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "verification.independence_required"
+    );
+    assert!(
+        !execution
+            .receipt
+            .body
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::Verification { .. }))
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
 fn same_inputs_produce_same_receipt_and_effect_digests() {
     fn successful_execution() -> gaap::runtime::AgentRunExecution {
         let run_request = request();
@@ -854,7 +1500,6 @@ fn same_inputs_produce_same_receipt_and_effect_digests() {
                 [
                     Ok(AgentStep::ProtectedEffect(Box::new(proposal(
                         effect.clone(),
-                        allow_permission(),
                     )))),
                     Ok(AgentStep::Finish),
                 ],

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1335,11 +1335,101 @@ fn executor_denial_is_normalized_to_non_execution_result() {
         execution.protected_effect_results[0].body.execution_status,
         EffectExecutionStatus::Denied
     );
+    assert_eq!(execution.receipt.body.usage.cost_micros, 10);
     assert!(
         execution.protected_effect_results[0]
             .body
             .executor
             .is_none()
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn budget_overrun_does_not_mask_failed_executor_outcome() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut observation = failed_mutation_observation(post_subject);
+    observation.usage = usage(1_000_001);
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(observation)]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.failed"
+    );
+    assert_eq!(execution.receipt.body.usage.cost_micros, 1_000_001);
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn attempted_result_uses_trusted_executor_identity() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut observation = executed_observation(post_subject.clone());
+    observation.executor = None;
+    observation.sandbox_profile = None;
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    effect.clone(),
+                )))),
+                Ok(AgentStep::Finish),
+            ],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(observation)]),
+        ScriptedVerifier::new(passing_verification(&post_subject.digest)),
+    );
+
+    assert_eq!(
+        execution.protected_effect_results[0].body.executor,
+        Some(executor_identity())
+    );
+    assert_eq!(
+        execution.protected_effect_results[0].body.sandbox_profile,
+        Some(effect.sandbox_profile.clone())
     );
 
     verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1405,7 +1405,6 @@ fn attempted_result_uses_trusted_executor_identity() {
     let calls = Rc::new(RefCell::new(Vec::new()));
     let mut observation = executed_observation(post_subject.clone());
     observation.executor = None;
-    observation.sandbox_profile = None;
 
     let execution = run_with(
         run_request.clone(),
@@ -1440,6 +1439,43 @@ fn attempted_result_uses_trusted_executor_identity() {
         &execution.protected_effect_results[0],
     )
     .unwrap();
+}
+
+#[test]
+fn missing_observed_sandbox_fails_closed_without_fabricated_result() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut observation = executed_observation(post_subject);
+    observation.sandbox_profile = None;
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(observation)]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.untrusted_sandbox"
+    );
+    assert!(execution.protected_effect_results.is_empty());
+    assert_eq!(execution.receipt.body.usage.cost_micros, 10);
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
 }
 
 #[test]

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,0 +1,875 @@
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use gaap::contracts::{
+    AgentRunRequest, AgentRunStatus, ApprovalReference, CapabilityIdentity, ContractSupport,
+    EffectClass, EffectEvidenceReference, EffectEvidenceType, EffectExecutionStatus, EffectUsage,
+    EvidenceReference, EvidenceType, ExecutorIdentity, FilesystemAccess, InputMetadataEntry,
+    OperationFamily, PROTECTED_EFFECT_REQUEST_SCHEMA, PolicyIdentity, ProtectedEffectRequest,
+    Repeatability, RequestedScope, ResourceBudget, RunEvent, SandboxProfileIdentity, Subject,
+    SubjectKind, TaskSpec, VerificationIndependence, VerificationRequirement, VerificationVerdict,
+    canonical_resource_budget_digest, validate_request, verify_protected_effect_result,
+    verify_terminal_receipt,
+};
+use gaap::runtime::{
+    AgentAdapter, AgentRunContext, AgentRunEngine, AgentStep, BudgetThresholds,
+    ExecutorObservation, ExecutorPort, PermissionInput, PlanProposal, PolicyDecision,
+    ProtectedEffectProposal, RuntimeConfig, RuntimePortError, RuntimeSupport, VerificationContext,
+    VerificationReport, VerifierPort,
+};
+
+fn digest(byte: u8) -> String {
+    format!("sha256:{}", char::from(byte).to_string().repeat(64))
+}
+
+fn subject(digest: String) -> Subject {
+    Subject {
+        kind: SubjectKind::Repository,
+        locator: "https://example.invalid/repository".to_string(),
+        digest,
+    }
+}
+
+fn capability() -> CapabilityIdentity {
+    CapabilityIdentity {
+        name: "filesystem.write".to_string(),
+        version: "1.0.0".to_string(),
+        digest: digest(b'2'),
+    }
+}
+
+fn policy() -> PolicyIdentity {
+    PolicyIdentity {
+        name: "fixture-policy".to_string(),
+        version: "2026-09-03".to_string(),
+        digest: digest(b'3'),
+    }
+}
+
+fn approval_for(subject_digest: &str) -> ApprovalReference {
+    ApprovalReference {
+        approval_id: format!("approval-{subject_digest}"),
+        actor_id: "owner@example.com".to_string(),
+        scope: "subject".to_string(),
+        subject_digest: subject_digest.to_string(),
+        evidence: EvidenceReference {
+            evidence_type: EvidenceType::Approval,
+            digest: digest(b'4'),
+            locator: Some("approval://fixture".to_string()),
+        },
+    }
+}
+
+fn evidence(evidence_type: EvidenceType, digest_byte: u8) -> EvidenceReference {
+    EvidenceReference {
+        evidence_type,
+        digest: digest(digest_byte),
+        locator: Some(format!("fixture://{}", char::from(digest_byte))),
+    }
+}
+
+fn effect_evidence(evidence_type: EffectEvidenceType, digest_byte: u8) -> EffectEvidenceReference {
+    EffectEvidenceReference {
+        evidence_type,
+        digest: digest(digest_byte),
+        locator: Some(format!("fixture://effect/{}", char::from(digest_byte))),
+    }
+}
+
+fn request() -> AgentRunRequest {
+    AgentRunRequest {
+        schema_version: gaap::contracts::AGENT_RUN_REQUEST_SCHEMA.to_owned(),
+        request_id: "run-fixture".to_string(),
+        run_id: "run-fixture".to_string(),
+        subject: subject(digest(b'1')),
+        requested_capability: capability(),
+        task: TaskSpec {
+            instructions: "Implement the approved change.".to_string(),
+            constraints: vec!["Do not publish a release.".to_string()],
+        },
+        policies: vec![policy()],
+        resource_budget: ResourceBudget {
+            max_cost_micros: 1_000_000,
+            max_elapsed_ms: 60_000,
+            max_model_tokens: 100_000,
+            max_tool_calls: 100,
+        },
+        approval_context: vec![approval_for(&digest(b'1'))],
+        required_verification: VerificationRequirement {
+            independence: VerificationIndependence::DifferentActor,
+            evidence_types: vec![EvidenceType::CommandOutput, EvidenceType::Artifact],
+        },
+    }
+}
+
+fn support() -> ContractSupport {
+    ContractSupport::new([policy()])
+}
+
+fn runtime_support(trusted_capabilities: Vec<CapabilityIdentity>) -> RuntimeSupport {
+    RuntimeSupport::new(support(), trusted_capabilities)
+}
+
+fn config() -> RuntimeConfig {
+    RuntimeConfig {
+        implementer_id: "runtime-test-engine".to_string(),
+        max_effects: 4,
+        budget_thresholds: BudgetThresholds {
+            warn_micros: 800_000,
+            approval_micros: 900_000,
+            hard_stop_micros: 1_000_000,
+        },
+    }
+}
+
+fn effect_request(
+    request: &AgentRunRequest,
+    support: &ContractSupport,
+    effect_sequence: u64,
+) -> ProtectedEffectRequest {
+    let request_digest = validate_request(request, support)
+        .expect("fixture request should validate")
+        .to_owned();
+    let budget_digest = canonical_resource_budget_digest(&request.resource_budget)
+        .expect("fixture budget should canonicalize");
+
+    ProtectedEffectRequest {
+        schema_version: PROTECTED_EFFECT_REQUEST_SCHEMA.to_owned(),
+        effect_id: format!("effect-{effect_sequence}"),
+        effect_sequence,
+        run_id: request.run_id.clone(),
+        agent_run_request_digest: request_digest,
+        subject: request.subject.clone(),
+        operation_family: OperationFamily::Filesystem,
+        normalized_operation: "filesystem.write".to_string(),
+        capability: request.requested_capability.clone(),
+        tool_schema_digest: Some(digest(b'6')),
+        input_digest: digest(b'7'),
+        input_metadata: vec![InputMetadataEntry {
+            name: "path".to_string(),
+            value: "artifact.txt".to_string(),
+        }],
+        requested_scopes: vec![RequestedScope::Filesystem {
+            root: "/workspace".to_string(),
+            access: vec![FilesystemAccess::Read, FilesystemAccess::Modify],
+            recursive: true,
+        }],
+        policies: request.policies.clone(),
+        approval_context: vec![approval_for(&request.subject.digest)],
+        resource_budget_digest: budget_digest,
+        sandbox_profile: SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        },
+        idempotency_key: format!("{}/effect-{effect_sequence}", request.run_id),
+        repeatability: Repeatability::Idempotent,
+        expected_effect_class: EffectClass::Mutation,
+    }
+}
+
+fn allow_permission() -> PermissionInput {
+    PermissionInput {
+        policy_decision: Some(PolicyDecision::Allow),
+        risk_tags: vec![],
+        wrapper_chain: vec![],
+        approval: None,
+    }
+}
+
+fn ask_permission() -> PermissionInput {
+    PermissionInput {
+        policy_decision: Some(PolicyDecision::Ask),
+        risk_tags: vec![],
+        wrapper_chain: vec![],
+        approval: None,
+    }
+}
+
+fn deny_permission() -> PermissionInput {
+    PermissionInput {
+        policy_decision: Some(PolicyDecision::Deny),
+        risk_tags: vec![],
+        wrapper_chain: vec![],
+        approval: None,
+    }
+}
+
+fn plan_for(request: &AgentRunRequest) -> PlanProposal {
+    PlanProposal {
+        plan_digest: digest(b'6'),
+        approval: Some(approval_for(&request.subject.digest)),
+    }
+}
+
+fn proposal(
+    effect: ProtectedEffectRequest,
+    permission: PermissionInput,
+) -> ProtectedEffectProposal {
+    proposal_with_cost(effect, permission, 10)
+}
+
+fn proposal_with_cost(
+    effect: ProtectedEffectRequest,
+    permission: PermissionInput,
+    estimated_cost_micros: u64,
+) -> ProtectedEffectProposal {
+    ProtectedEffectProposal {
+        request: effect,
+        permission,
+        estimated_cost_micros,
+    }
+}
+
+fn executor_identity() -> ExecutorIdentity {
+    ExecutorIdentity {
+        name: "test-executor".to_string(),
+        version: "0.1.0".to_string(),
+        digest: digest(b'9'),
+    }
+}
+
+fn usage(cost: u64) -> EffectUsage {
+    EffectUsage {
+        cost_micros: cost,
+        elapsed_ms: 10,
+        model_tokens: 0,
+        tool_calls: 1,
+    }
+}
+
+fn executed_observation(next_subject: Subject) -> ExecutorObservation {
+    ExecutorObservation {
+        execution_status: EffectExecutionStatus::Executed,
+        observed_post_effect_subject: Some(next_subject),
+        exit: None,
+        usage: usage(10),
+        executor: Some(executor_identity()),
+        sandbox_profile: Some(SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        }),
+        reason: None,
+        evidence: vec![
+            effect_evidence(EffectEvidenceType::Executor, b'a'),
+            effect_evidence(EffectEvidenceType::Artifact, b'b'),
+            effect_evidence(EffectEvidenceType::Sandbox, b'0'),
+            effect_evidence(EffectEvidenceType::SubjectObservation, b'1'),
+            effect_evidence(EffectEvidenceType::Mutation, b'2'),
+            effect_evidence(EffectEvidenceType::Usage, b'3'),
+            effect_evidence(EffectEvidenceType::Output, b'4'),
+        ],
+    }
+}
+
+fn executed_observation_with_cost(next_subject: Subject, cost_micros: u64) -> ExecutorObservation {
+    let mut observation = executed_observation(next_subject);
+    observation.usage = usage(cost_micros);
+    observation
+}
+
+fn unknown_outcome_observation() -> ExecutorObservation {
+    ExecutorObservation {
+        execution_status: EffectExecutionStatus::UnknownOutcome,
+        observed_post_effect_subject: None,
+        exit: None,
+        usage: usage(10),
+        executor: Some(executor_identity()),
+        sandbox_profile: Some(SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        }),
+        reason: Some("executor lost post-effect visibility".to_string()),
+        evidence: vec![
+            effect_evidence(EffectEvidenceType::Executor, b'a'),
+            effect_evidence(EffectEvidenceType::Sandbox, b'0'),
+            effect_evidence(EffectEvidenceType::Usage, b'3'),
+            effect_evidence(EffectEvidenceType::UnknownOutcome, b'5'),
+        ],
+    }
+}
+
+fn interrupted_observation() -> ExecutorObservation {
+    ExecutorObservation {
+        execution_status: EffectExecutionStatus::Interrupted,
+        observed_post_effect_subject: Some(subject(digest(b'1'))),
+        exit: None,
+        usage: usage(10),
+        executor: Some(executor_identity()),
+        sandbox_profile: Some(SandboxProfileIdentity {
+            name: "sandbox-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            digest: digest(b'8'),
+        }),
+        reason: Some("operator interrupted run".to_string()),
+        evidence: vec![
+            effect_evidence(EffectEvidenceType::Executor, b'a'),
+            effect_evidence(EffectEvidenceType::Artifact, b'b'),
+            effect_evidence(EffectEvidenceType::Sandbox, b'0'),
+            effect_evidence(EffectEvidenceType::SubjectObservation, b'1'),
+            effect_evidence(EffectEvidenceType::Mutation, b'2'),
+            effect_evidence(EffectEvidenceType::Usage, b'3'),
+            effect_evidence(EffectEvidenceType::Interruption, b'5'),
+        ],
+    }
+}
+
+fn passing_verification(subject_digest: &str) -> VerificationReport {
+    VerificationReport {
+        subject_digest: subject_digest.to_string(),
+        verifier_id: "fixture-verifier".to_string(),
+        verdict: VerificationVerdict::Pass,
+        evidence: vec![
+            evidence(EvidenceType::CommandOutput, b'c'),
+            evidence(EvidenceType::Artifact, b'd'),
+        ],
+    }
+}
+
+struct ScriptedAgent {
+    plan: Option<Result<PlanProposal, RuntimePortError>>,
+    steps: VecDeque<Result<AgentStep, RuntimePortError>>,
+}
+
+impl ScriptedAgent {
+    fn new(
+        plan: PlanProposal,
+        steps: impl IntoIterator<Item = Result<AgentStep, RuntimePortError>>,
+    ) -> Self {
+        Self {
+            plan: Some(Ok(plan)),
+            steps: steps.into_iter().collect(),
+        }
+    }
+}
+
+impl AgentAdapter for ScriptedAgent {
+    fn plan(&mut self, _request: &AgentRunRequest) -> Result<PlanProposal, RuntimePortError> {
+        self.plan
+            .take()
+            .expect("agent plan should be called exactly once")
+    }
+
+    fn next_effect(
+        &mut self,
+        _context: AgentRunContext<'_>,
+    ) -> Result<AgentStep, RuntimePortError> {
+        self.steps
+            .pop_front()
+            .expect("agent should have another scripted step")
+    }
+}
+
+struct RecordingExecutor {
+    calls: Rc<RefCell<Vec<String>>>,
+    observations: VecDeque<Result<ExecutorObservation, RuntimePortError>>,
+}
+
+impl RecordingExecutor {
+    fn new(
+        calls: Rc<RefCell<Vec<String>>>,
+        observations: impl IntoIterator<Item = Result<ExecutorObservation, RuntimePortError>>,
+    ) -> Self {
+        Self {
+            calls,
+            observations: observations.into_iter().collect(),
+        }
+    }
+}
+
+impl ExecutorPort for RecordingExecutor {
+    fn execute(
+        &mut self,
+        request: &ProtectedEffectRequest,
+    ) -> Result<ExecutorObservation, RuntimePortError> {
+        self.calls.borrow_mut().push(request.effect_id.clone());
+        self.observations
+            .pop_front()
+            .expect("executor should have another scripted observation")
+    }
+}
+
+struct ScriptedVerifier {
+    report: Option<Result<VerificationReport, RuntimePortError>>,
+}
+
+impl ScriptedVerifier {
+    fn new(report: VerificationReport) -> Self {
+        Self {
+            report: Some(Ok(report)),
+        }
+    }
+}
+
+impl VerifierPort for ScriptedVerifier {
+    fn verify(
+        &mut self,
+        _context: VerificationContext<'_>,
+    ) -> Result<VerificationReport, RuntimePortError> {
+        self.report
+            .take()
+            .expect("verifier should be called exactly once")
+    }
+}
+
+fn run_with(
+    run_request: AgentRunRequest,
+    runtime_support: RuntimeSupport,
+    agent: ScriptedAgent,
+    executor: RecordingExecutor,
+    verifier: ScriptedVerifier,
+) -> gaap::runtime::AgentRunExecution {
+    let mut engine = AgentRunEngine::new(runtime_support, config(), agent, executor, verifier);
+    engine
+        .run(run_request)
+        .expect("runtime should return receipt")
+}
+
+#[test]
+fn completed_run_returns_a_sealed_terminal_receipt_and_effect_result() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    effect.clone(),
+                    allow_permission(),
+                )))),
+                Ok(AgentStep::Finish),
+            ],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Ok(executed_observation(post_subject.clone()))],
+        ),
+        ScriptedVerifier::new(passing_verification(&post_subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Completed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "workflow.completion_authorized"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(execution.receipt.body.usage.cost_micros, 10);
+    assert_eq!(execution.protected_effect_results.len(), 1);
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::Executed
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn ask_decision_terminalizes_without_invoking_executor() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+                ask_permission(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "permission.policy_requires_approval"
+    );
+    assert!(calls.borrow().is_empty());
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::AwaitingAuthority
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn denied_effect_terminalizes_without_invoking_executor() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+                deny_permission(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(execution.receipt.body.terminal_reason, "permission.denied");
+    assert!(calls.borrow().is_empty());
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::Denied
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn untrusted_capability_blocks_before_executor() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+                allow_permission(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "tool_trust.approval_required"
+    );
+    assert!(calls.borrow().is_empty());
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::Denied
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn runtime_hard_stop_blocks_before_executor() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(
+                proposal_with_cost(effect.clone(), allow_permission(), 1_000_000),
+            )))],
+        ),
+        RecordingExecutor::new(calls.clone(), []),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(execution.receipt.body.terminal_reason, "runtime.hard_stop");
+    assert!(calls.borrow().is_empty());
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::Denied
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn actual_usage_over_budget_blocks_before_verification() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+                allow_permission(),
+            ))))],
+        ),
+        RecordingExecutor::new(
+            calls.clone(),
+            [Ok(executed_observation_with_cost(post_subject, 1_000_001))],
+        ),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "runtime.budget_exceeded"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(execution.receipt.body.usage.cost_micros, 1_000_001);
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::Executed
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn executor_unknown_outcome_is_distinct_from_failure() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+                allow_permission(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(unknown_outcome_observation())]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.unknown_outcome"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::UnknownOutcome
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn interrupted_effect_produces_interrupted_receipt() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+                allow_permission(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(interrupted_observation())]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Interrupted
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.interrupted"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert!(
+        execution
+            .receipt
+            .body
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::Interruption { .. }))
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn stale_verification_blocks_completion() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [
+                Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                    effect.clone(),
+                    allow_permission(),
+                )))),
+                Ok(AgentStep::Finish),
+            ],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(executed_observation(post_subject))]),
+        ScriptedVerifier::new(passing_verification(&digest(b'f'))),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Blocked
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "verification.stale_subject"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+}
+
+#[test]
+fn same_inputs_produce_same_receipt_and_effect_digests() {
+    fn successful_execution() -> gaap::runtime::AgentRunExecution {
+        let run_request = request();
+        let support = support();
+        let effect = effect_request(&run_request, &support, 1);
+        let post_subject = subject(digest(b'e'));
+        let calls = Rc::new(RefCell::new(Vec::new()));
+
+        run_with(
+            run_request.clone(),
+            runtime_support(vec![run_request.requested_capability.clone()]),
+            ScriptedAgent::new(
+                plan_for(&run_request),
+                [
+                    Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                        effect.clone(),
+                        allow_permission(),
+                    )))),
+                    Ok(AgentStep::Finish),
+                ],
+            ),
+            RecordingExecutor::new(calls, [Ok(executed_observation(post_subject.clone()))]),
+            ScriptedVerifier::new(passing_verification(&post_subject.digest)),
+        )
+    }
+
+    let first = successful_execution();
+    let second = successful_execution();
+
+    assert_eq!(first.receipt.receipt_digest, second.receipt.receipt_digest);
+    assert_eq!(
+        first.protected_effect_results[0].result_digest,
+        second.protected_effect_results[0].result_digest
+    );
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1588,6 +1588,97 @@ fn mismatched_observed_sandbox_records_attempted_mutation() {
 }
 
 #[test]
+fn malformed_untrusted_sandbox_observation_still_returns_failed_receipt() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut observation = executed_observation(subject(digest(b'e')));
+    observation.sandbox_profile = None;
+    observation.observed_post_effect_subject = Some(Subject {
+        kind: SubjectKind::Repository,
+        locator: String::new(),
+        digest: "not-a-digest".to_string(),
+    });
+    observation.usage = EffectUsage {
+        cost_micros: 9_007_199_254_740_992,
+        elapsed_ms: 9_007_199_254_740_992,
+        model_tokens: 9_007_199_254_740_992,
+        tool_calls: 9_007_199_254_740_992,
+    };
+    let duplicate_evidence = effect_evidence(EffectEvidenceType::Usage, b'3');
+    observation.evidence = vec![
+        EffectEvidenceReference {
+            evidence_type: EffectEvidenceType::Executor,
+            digest: "not-a-digest".to_string(),
+            locator: Some(String::new()),
+        },
+        duplicate_evidence.clone(),
+        duplicate_evidence,
+        effect_evidence(EffectEvidenceType::Failure, b'5'),
+        effect_evidence(EffectEvidenceType::Interruption, b'6'),
+    ];
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(observation)]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.untrusted_sandbox"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(
+        execution.receipt.body.resulting_subject_digest,
+        run_request.subject.digest
+    );
+    assert_eq!(execution.protected_effect_results.len(), 1);
+    let result = &execution.protected_effect_results[0];
+    assert_eq!(
+        result.body.execution_status,
+        EffectExecutionStatus::UnknownOutcome
+    );
+    assert!(result.body.observed_post_effect_subject.is_none());
+    assert_eq!(result.body.usage.cost_micros, 9_007_199_254_740_991);
+    assert_eq!(result.body.usage.elapsed_ms, 9_007_199_254_740_991);
+    assert_eq!(result.body.usage.model_tokens, 9_007_199_254_740_991);
+    assert_eq!(result.body.usage.tool_calls, 9_007_199_254_740_991);
+    assert!(
+        result
+            .body
+            .evidence
+            .iter()
+            .any(|item| item.evidence_type == EffectEvidenceType::UnknownOutcome)
+    );
+    assert!(!result.body.evidence.iter().any(|item| matches!(
+        item.evidence_type,
+        EffectEvidenceType::Failure | EffectEvidenceType::Interruption
+    )));
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
 fn executor_error_records_unknown_outcome_result() {
     let run_request = request();
     let support = support();

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1442,13 +1442,13 @@ fn attempted_result_uses_trusted_executor_identity() {
 }
 
 #[test]
-fn missing_observed_sandbox_fails_closed_without_fabricated_result() {
+fn missing_observed_sandbox_records_attempted_mutation() {
     let run_request = request();
     let support = support();
     let effect = effect_request(&run_request, &support, 1);
     let post_subject = subject(digest(b'e'));
     let calls = Rc::new(RefCell::new(Vec::new()));
-    let mut observation = executed_observation(post_subject);
+    let mut observation = executed_observation(post_subject.clone());
     observation.sandbox_profile = None;
 
     let execution = run_with(
@@ -1472,10 +1472,119 @@ fn missing_observed_sandbox_fails_closed_without_fabricated_result() {
         execution.receipt.body.terminal_reason,
         "protected_effect.untrusted_sandbox"
     );
-    assert!(execution.protected_effect_results.is_empty());
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
     assert_eq!(execution.receipt.body.usage.cost_micros, 10);
+    assert_eq!(execution.protected_effect_results.len(), 1);
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::UnknownOutcome
+    );
+    assert_eq!(
+        execution.protected_effect_results[0]
+            .body
+            .observed_post_effect_subject,
+        Some(post_subject.clone())
+    );
+    assert_eq!(
+        execution.protected_effect_results[0].body.sandbox_profile,
+        Some(effect.sandbox_profile.clone())
+    );
+    assert!(
+        execution.protected_effect_results[0]
+            .body
+            .evidence
+            .iter()
+            .any(|item| item.evidence_type == EffectEvidenceType::UnknownOutcome)
+    );
+    assert_eq!(
+        execution.receipt.body.resulting_subject_digest,
+        post_subject.digest
+    );
+    assert!(
+        execution
+            .receipt
+            .body
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::ToolExecution { .. }))
+    );
+    assert!(execution.receipt.body.events.iter().any(|event| matches!(
+        event,
+        RunEvent::Mutation {
+            after_subject_digest,
+            ..
+        } if after_subject_digest == &post_subject.digest
+    )));
 
     verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
+}
+
+#[test]
+fn mismatched_observed_sandbox_records_attempted_mutation() {
+    let run_request = request();
+    let support = support();
+    let effect = effect_request(&run_request, &support, 1);
+    let post_subject = subject(digest(b'e'));
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let mut observation = executed_observation(post_subject.clone());
+    observation.sandbox_profile = Some(SandboxProfileIdentity {
+        name: "different-sandbox".to_string(),
+        version: "0.1.0".to_string(),
+        digest: digest(b'f'),
+    });
+
+    let execution = run_with(
+        run_request.clone(),
+        runtime_support(vec![run_request.requested_capability.clone()]),
+        ScriptedAgent::new(
+            plan_for(&run_request),
+            [Ok(AgentStep::ProtectedEffect(Box::new(proposal(
+                effect.clone(),
+            ))))],
+        ),
+        RecordingExecutor::new(calls.clone(), [Ok(observation)]),
+        ScriptedVerifier::new(passing_verification(&run_request.subject.digest)),
+    );
+
+    assert_eq!(
+        execution.receipt.body.terminal_status,
+        AgentRunStatus::Failed
+    );
+    assert_eq!(
+        execution.receipt.body.terminal_reason,
+        "protected_effect.untrusted_sandbox"
+    );
+    assert_eq!(calls.borrow().as_slice(), ["effect-1"]);
+    assert_eq!(
+        execution.protected_effect_results[0].body.execution_status,
+        EffectExecutionStatus::UnknownOutcome
+    );
+    assert_eq!(
+        execution.protected_effect_results[0]
+            .body
+            .observed_post_effect_subject,
+        Some(post_subject.clone())
+    );
+    assert_eq!(
+        execution.receipt.body.resulting_subject_digest,
+        post_subject.digest
+    );
+
+    verify_terminal_receipt(&run_request, &support, &execution.receipt).unwrap();
+    verify_protected_effect_result(
+        &run_request,
+        &support,
+        &effect,
+        &execution.protected_effect_results[0],
+    )
+    .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `gaap::runtime`, a Rust-only bounded Agent Run engine around `RunCoordinator`
- Evaluate plan, permission, tool-trust, runtime budget, workflow, execution, and verification gates before sealing one terminal receipt
- Add runtime tests for completion, ask/deny, untrusted capabilities, runtime budget stops, over-budget usage, interruption, unknown outcome, stale verification, and deterministic digests
- Add a runtime CI lane and ADR 0005 documenting the ToolTrust authority decision

## ToolTrust authority
ToolTrust authority comes from `RuntimeSupport.trusted_capabilities` and is translated into the coordinator capability-bound approval input. The frozen Agent Run and Protected Effect v0.1 approval references remain subject-bound.

## Verification
- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo run --locked --example generate-contract-artifacts -- --check`
- `bash .github/scripts/test-select-ci-lanes.sh`

Closes #11